### PR TITLE
Add Discord Rich Presence integration

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -495,7 +495,7 @@ checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
 dependencies = [
  "byteorder",
  "fnv",
- "uuid",
+ "uuid 1.23.4",
 ]
 
 [[package]]
@@ -880,6 +880,19 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "discord-rich-presence"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75db747ecd252c01bfecaf709b07fcb4c634adf0edb5fed47bc9c3052e7076b"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -2348,7 +2361,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tungstenite",
  "ureq",
- "uuid",
+ "uuid 1.23.4",
 ]
 
 [[package]]
@@ -3395,6 +3408,7 @@ dependencies = [
 name = "sard"
 version = "1.2.2"
 dependencies = [
+ "discord-rich-presence",
  "image",
  "msedge-tts",
  "quick-xml 0.36.2",
@@ -3438,7 +3452,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "uuid",
+ "uuid 1.23.4",
 ]
 
 [[package]]
@@ -4111,7 +4125,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "url",
- "uuid",
+ "uuid 1.23.4",
  "walkdir",
 ]
 
@@ -4352,7 +4366,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
- "uuid",
+ "uuid 1.23.4",
  "walkdir",
 ]
 
@@ -4921,6 +4935,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "uuid"
@@ -5806,7 +5829,7 @@ dependencies = [
  "serde_repr",
  "tracing",
  "uds_windows",
- "uuid",
+ "uuid 1.23.4",
  "windows-sys 0.61.2",
  "winnow 1.0.3",
  "zbus_macros",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ diag = []
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+discord-rich-presence = "0.2"
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 # The OFFICIAL in-app updater: fetches a signed manifest from GitHub Releases, verifies the

--- a/src-tauri/src/commands/discord.rs
+++ b/src-tauri/src/commands/discord.rs
@@ -1,0 +1,28 @@
+// src-tauri/src/commands/discord.rs
+//
+// Frontend-facing commands for Discord Rich Presence.
+// Add `mod discord;` to commands/mod.rs and register these
+// three functions in the invoke_handler! list in lib.rs.
+
+use crate::discord_rpc::{self, DiscordState};
+use tauri::State;
+
+#[tauri::command]
+pub fn discord_set_reading(
+    state: State<DiscordState>,
+    title: String,
+    author: Option<String>,
+    chapter: Option<String>,
+    progress_pct: Option<u8>,
+) {
+    discord_rpc::set_reading(&state, &title, author.as_deref(), chapter.as_deref(), progress_pct);
+}
+
+#[tauri::command]
+pub fn discord_clear(state: State<DiscordState>) {
+    discord_rpc::clear(&state);
+}
+#[tauri::command]
+pub fn discord_set_browsing(state: State<DiscordState>) {
+    discord_rpc::set_browsing(&state);
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,7 +8,8 @@ use tauri::State;
 
 use crate::db::{self, AppState};
 use crate::{backgrounds, books, fonts, library, photocards, settings};
-
+mod discord;
+pub use discord::*;
 #[derive(Serialize)]
 pub struct AppInfo {
     /// THE BUILD ID baked in at compile time (build.rs). Product metadata, not instrumentation:

--- a/src-tauri/src/discord_rpc.rs
+++ b/src-tauri/src/discord_rpc.rs
@@ -1,0 +1,165 @@
+// src-tauri/src/discord_rpc.rs
+//
+// Discord Rich Presence integration.
+// Shows the currently-open book (title + optional author/progress)
+// on the user's Discord profile, if they opt in via Settings.
+
+use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+// Replace with your own Discord Application ID from
+// https://discord.com/developers/applications
+const DISCORD_APP_ID: &str = "1421191366247186563";
+
+pub struct DiscordState(pub Mutex<Option<DiscordIpcClient>>);
+
+impl Default for DiscordState {
+    fn default() -> Self {
+        DiscordState(Mutex::new(None))
+    }
+}
+
+/// Try to connect to a locally-running Discord client.
+/// Safe to call even if Discord isn't running - just returns None.
+fn try_connect() -> Option<DiscordIpcClient> {
+    let mut client = DiscordIpcClient::new(DISCORD_APP_ID).ok()?;
+    client.connect().ok()?;
+    Some(client)
+}
+
+/// Call this once at app startup (from lib.rs setup) to establish
+/// the initial connection, if Discord happens to already be open.
+pub fn init() -> DiscordState {
+    DiscordState(Mutex::new(try_connect()))
+}
+
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Wrap a segment in Unicode "First Strong Isolate" / "Pop Directional Isolate"
+/// marks (U+2068 / U+2069). This tells the bidi algorithm to treat the segment
+/// as its own isolated run, using ITS OWN first-strong-character direction,
+/// rather than letting neighbouring RTL/LTR text (e.g. an Arabic chapter title
+/// next to a "26%" figure) reorder pieces visually. Cheap, invisible, and the
+/// standard fix for exactly this "mixed RTL text + number" garbling.
+fn isolate(s: &str) -> String {
+    format!("\u{2068}{}\u{2069}", s)
+}
+
+/// Update presence to show the book currently being read.
+///
+/// `title` - book title, shown as the top line ("Reading <title>")
+/// `author` - optional author, shown as the second line
+/// `progress_pct` - optional 0-100 reading progress, appended to the second line
+pub fn set_reading(
+    state: &DiscordState,
+    title: &str,
+    author: Option<&str>,
+    chapter: Option<&str>,
+    progress_pct: Option<u8>,
+) {
+    let mut guard = state.0.lock().unwrap();
+
+    // Lazily (re)connect if we don't have a live client yet -
+    // handles the case where Discord was closed when Sard started.
+    if guard.is_none() {
+        *guard = try_connect();
+    }
+
+    let Some(client) = guard.as_mut() else {
+        return; // Discord not running - silently no-op
+    };
+
+    let details = format!("Reading {}", title);
+
+    // Build the second line as: "by <author> · <chapter> · <pct>%",
+    // dropping any part that isn't available.
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(a) = author {
+        parts.push(isolate(&format!("by {}", a)));
+    }
+    if let Some(c) = chapter {
+        parts.push(isolate(c));
+    }
+    if let Some(p) = progress_pct {
+        parts.push(isolate(&format!("{}%", p)));
+    }
+    let state_line = parts.join(" · ");
+
+    let mut activity_builder = activity::Activity::new()
+        .details(&details)
+        .activity_type(activity::ActivityType::Playing)
+        .assets(
+            activity::Assets::new()
+                .large_image("sard_logo")
+                .large_text("Sard"),
+        )
+        .buttons(vec![activity::Button::new(
+            "Get Sard",
+            "https://github.com/Limitless-Soul1/Sard",
+        )])
+        .timestamps(activity::Timestamps::new().start(now_unix()));
+
+    if !state_line.is_empty() {
+        activity_builder = activity_builder.state(&state_line);
+    }
+
+    // If set_activity fails (e.g. Discord was closed mid-session),
+    // drop the stale client so the next call retries a fresh connect.
+    if client.set_activity(activity_builder).is_err() {
+        *guard = None;
+    }
+}
+
+/// Clear presence - call when a book is closed or the app goes idle.
+pub fn clear(state: &DiscordState) {
+    let mut guard = state.0.lock().unwrap();
+    if let Some(client) = guard.as_mut() {
+        let _ = client.clear_activity();
+    }
+}
+
+/// Show a generic "browsing the library" presence, for when a book is closed
+/// but the app is still open - nicer than going fully blank on Discord.
+pub fn set_browsing(state: &DiscordState) {
+    let mut guard = state.0.lock().unwrap();
+
+    if guard.is_none() {
+        *guard = try_connect();
+    }
+
+    let Some(client) = guard.as_mut() else {
+        return;
+    };
+
+    let activity_builder = activity::Activity::new()
+        .details("Browsing the library")
+        .activity_type(activity::ActivityType::Playing)
+        .assets(
+            activity::Assets::new()
+                .large_image("sard_logo")
+                .large_text("Sard"),
+        )
+        .buttons(vec![activity::Button::new(
+            "Get Sard",
+            "https://github.com/Limitless-Soul1/Sard",
+        )])
+        .timestamps(activity::Timestamps::new().start(now_unix()));
+
+    if client.set_activity(activity_builder).is_err() {
+        *guard = None;
+    }
+}
+
+/// Disconnect cleanly - call on app shutdown.
+pub fn shutdown(state: &DiscordState) {
+    let mut guard = state.0.lock().unwrap();
+    if let Some(mut client) = guard.take() {
+        let _ = client.close();
+    }
+}

--- a/src-tauri/src/discord_rpc.rs
+++ b/src-tauri/src/discord_rpc.rs
@@ -8,9 +8,10 @@ use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-// Replace with your own Discord Application ID from
-// https://discord.com/developers/applications
-const DISCORD_APP_ID: &str = "1421191366247186563";
+// TODO(maintainer): replace with Sard's own Discord Application ID before release.
+// Create one at https://discord.com/developers/applications, then upload a "sard_logo"
+// image under Rich Presence -> Art Assets using that same application.
+const DISCORD_APP_ID: &str = "YOUR_DISCORD_APPLICATION_ID_HERE";
 
 pub struct DiscordState(pub Mutex<Option<DiscordIpcClient>>);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,7 @@ pub mod sync; // FUTURE seam: backend trait only (placeholder)
 pub mod tts; // RAWY-105: bundled piper sidecar (persistent process) + on-demand voice download
 pub mod webview_chrome; // RAWY-196: strip WebView2's browser chrome + accelerators (find bar, reload, print)
 pub mod window_chrome; // RAWY-118: theme the native title bar to match the app theme (DWM, Windows)
+pub mod discord_rpc; // Discord Rich Presence (optional, opt-in)
 
 use std::path::Path;
 
@@ -98,6 +99,9 @@ macro_rules! sard_invoke_handler {
             commands::book_register,
             commands::progress_save,
             commands::progress_get,
+            commands::discord_set_reading,
+            commands::discord_clear,
+            commands::discord_set_browsing,
             commands::library_list_books,
             commands::collections_list,
             commands::collection_create,
@@ -251,6 +255,7 @@ pub fn run() {
                 db_path,
             });
             app.manage(tts::TtsEngine::default()); // RAWY-105: persistent piper process holder
+            app.manage(discord_rpc::init());
             Ok(())
         });
 
@@ -276,6 +281,9 @@ pub fn run() {
             if let tauri::RunEvent::ExitRequested { .. } = event {
                 if let Some(engine) = app_handle.try_state::<tts::TtsEngine>() {
                     tts::shutdown(&engine);
+                }
+                if let Some(discord) = app_handle.try_state::<discord_rpc::DiscordState>() {
+                    discord_rpc::shutdown(&discord);
                 }
             }
         });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,9 @@ import { Library, type OpenTarget } from "./features/library/Library";
 import { Reader } from "./features/reader/Reader";
 import { RuntimeGate } from "./app/RuntimeGate"; // RESILIENCE-1 / WP-1
 import { canRender } from "./lib/runtime";
-import { libraryListBooks, settingsGet, settingsSet } from "./lib/ipc";
+import { libraryListBooks, settingsGet, settingsSet, discordClear } from "./lib/ipc";
+import { initDiscordSettings, useDiscordSettings } from "./lib/discordSettings";
+import { initDiscordPresence, showBrowsingPresence } from "./reader-engine/discordPresence";
 
 // RAWY-12 i18n + RAWY-13 themes + RAWY-15 Library home. First run shows the language
 // picker; afterwards the saved language/theme drive the UI and the Library is the home
@@ -38,6 +40,13 @@ function Root() {
     })().catch(console.error);
   }, []);
 
+  // Discord: no book open (initial launch, or after backing out of one) -> "Browsing the library".
+  useEffect(() => {
+    if (!open) {
+      showBrowsingPresence();
+    }
+  }, [open]);
+
   if (!i18nReady || !themeReady) return null; // brief: settings loading (avoids theme flash)
   // RESILIENCE-1 / WP-1: the runtime gate. foliate's OPF parser needs browser features an older
   // WebView2 does not have; without them NO book opens, so this is a genuine precondition rather
@@ -46,10 +55,12 @@ function Root() {
   // A missing PDF capability is NOT checked here — EPUB reading is unaffected by it (see RuntimeGate).
   if (!canRender("epub")) return <RuntimeGate />;
   if (!hasLang) return <LanguagePicker />;
-  // RAWY-206: `onOpenBook` is the SAME `setOpen` the Library hands a book to — the reader's Notes panel
-  // uses it to open another book at a note's locator, so there is one open path, not two.
   return open ? (
-    <Reader book={open} onExit={() => setOpen(null)} onOpenBook={setOpen} />
+    <Reader
+      book={open}
+      onExit={() => setOpen(null)}
+      onOpenBook={setOpen}
+    />
   ) : (
     <Library onOpen={setOpen} />
   );
@@ -70,6 +81,30 @@ function App() {
     // Applying it later would paint the themed ground first and then swap — the RAWY-118 class of flash.
     initBackground();
     registerOutcomeRecorder(); // RAWY-263: observe listening outcomes locally. Read-only; never writes while audio plays.
+    initDiscordSettings(); // load persisted Discord presence settings
+  }, []);
+
+  // Discord Rich Presence — opt-in, off by default. Starts/stops the presence subscriber LIVE as the
+  // Sharing-tab master switch flips, so no restart is needed for the toggle to take effect.
+  useEffect(() => {
+    let stopDiscord: (() => void) | undefined;
+
+    const apply = (enabled: boolean) => {
+      if (enabled && !stopDiscord) {
+        stopDiscord = initDiscordPresence();
+      } else if (!enabled && stopDiscord) {
+        stopDiscord();
+        stopDiscord = undefined;
+        void discordClear().catch(() => {});
+      }
+    };
+
+    apply(useDiscordSettings.getState().enabled);
+    const unsub = useDiscordSettings.subscribe((s) => apply(s.enabled));
+    return () => {
+      unsub();
+      stopDiscord?.();
+    };
   }, []);
 
   // RAWY-265 — the library background is re-derived whenever the LIBRARY theme or any of its own

--- a/src/features/settings/GlobalSettings.tsx
+++ b/src/features/settings/GlobalSettings.tsx
@@ -32,15 +32,17 @@ import {
   type ReadingStyle,
 } from "../../reader-engine/injectedCss";
 import { THEMES, THEME_ORDER, currentMode, useTheme, type ThemeMode } from "../../theme";
+import { useDiscordSettings } from "../../lib/discordSettings";
 
 const STYLE_KEY = "reading_style";
 
-type Section = "appearance" | "fonts" | "reading" | "bookmark" | "language" | "about";
+type Section = "appearance" | "fonts" | "reading" | "bookmark" | "sharing" | "language" | "about";
 const NAV: { key: Section; label: TKey; icon: string }[] = [
   { key: "appearance", label: "gs.nav.appearance", icon: "◑" },
   { key: "fonts", label: "gs.nav.fonts", icon: "A" },
   { key: "reading", label: "gs.nav.reading", icon: "▤" },
   { key: "bookmark", label: "gs.nav.bookmark", icon: "▸" },
+  { key: "sharing", label: "gs.nav.sharing", icon: "⇪" },
   { key: "language", label: "gs.nav.language", icon: "⌘" },
   { key: "about", label: "gs.nav.about", icon: "ⓘ" },
 ];
@@ -90,6 +92,7 @@ export function GlobalSettings({ open, onClose }: { open: boolean; onClose: () =
             {section === "fonts" && <FontsSection />}
             {section === "reading" && <ReadingDefaultsSection />}
             {section === "bookmark" && <BookmarkSection />}
+            {section === "sharing" && <SharingSection />}
             {section === "language" && <LanguageSection />}
             {section === "about" && <AboutSection />}
           </div>
@@ -837,6 +840,65 @@ function BookmarkSection() {
     </>
   );
 }
+// ---- Sharing: Discord Rich Presence (and a home for future "share" features) ----
+
+function SharingSection() {
+  const { t } = useI18n();
+  return (
+    <>
+      <SecHead>{t("gs.sharing")}</SecHead>
+      <DiscordPresenceSection />
+    </>
+  );
+}
+
+function DiscordPresenceSection() {
+  const { t } = useI18n();
+  const {
+    enabled,
+    showTitle,
+    showChapter,
+    showProgress,
+    setEnabled,
+    setShowTitle,
+    setShowChapter,
+    setShowProgress,
+  } = useDiscordSettings();
+
+  return (
+    <div className="gs-sec">
+      <Label hint={t("gs.discord.hint")}>{t("gs.discord")}</Label>
+
+      <BgToggle
+        label={t("gs.discord.enable")}
+        hint={t("gs.discord.enableHint")}
+        on={enabled}
+        onToggle={() => setEnabled(!enabled)}
+      />
+
+      {enabled && (
+        <>
+          <BgToggle
+            label={t("gs.discord.showTitle")}
+            on={showTitle}
+            onToggle={() => setShowTitle(!showTitle)}
+          />
+          <BgToggle
+            label={t("gs.discord.showChapter")}
+            on={showChapter}
+            onToggle={() => setShowChapter(!showChapter)}
+          />
+          <BgToggle
+            label={t("gs.discord.showProgress")}
+            on={showProgress}
+            onToggle={() => setShowProgress(!showProgress)}
+          />
+          {!showTitle && <div className="gs-note">{t("gs.discord.hiddenNote")}</div>}
+        </>
+      )}
+    </div>
+  );
+}
 
 function LanguageSection() {
   const { t, lang, setLang } = useI18n();
@@ -921,7 +983,6 @@ function AboutSection() {
     </>
   );
 }
-
 // The explicit two-level distinction (design Band H) — global vs in-book.
 function TwoLevelCard() {
   const { t } = useI18n();

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -738,6 +738,7 @@ export const ar: Record<TKey, string> = {
   "tts.nextChapter": "الفصل التالي",
   "tts.bookEnd": "نهاية الكتاب",
 
+
   // ── RESILIENCE-1 / WP-1: سطح الأعطال ────────────────────────────────────────────────────────
   // كل نصّ هنا يجيب عن ثلاثة أسئلة بالترتيب: ما الذي فشل · على مَن تقع المسؤولية · ما الخطوة التالية.
   // السبب التقني لا يظهر في النصّ إطلاقًا — مكانه خلف «التفاصيل».
@@ -812,4 +813,17 @@ export const ar: Record<TKey, string> = {
   "meta.titleFrom.inferred": "مأخوذ من أول عنوان داخل الكتاب.",
   "meta.titleFrom.filename": "مأخوذ من اسم الملفّ.",
   "meta.titleFrom.default": "لم يقدّم هذا الكتاب عنوانًا صالحًا.",
+
+//اعدادات الدسكورد
+"gs.nav.sharing": "المشاركة",
+"gs.sharing": "المشاركة",
+"gs.discord": "دسكورد",
+"gs.discord.hint": "شارك ما تقرأه على الدسكورد",
+"gs.discord.enable": "إظهار نشاط القراءة في الدسكورد",
+"gs.discord.enableHint": "لا يُرسل شيء ما لم يكن هذا الخيار مفعّلاً. يتطلب تشغيل الدسكورد على سطح المكتب.",
+"gs.discord.showTitle": "إظهار عنوان الكتاب",
+"gs.discord.showChapter": "إظهار عنوان الفصل",
+"gs.discord.showProgress": " إظهار تقدم القراءة %", 
+"gs.discord.hiddenNote": "سيرى أصدقاؤك «Reading a book» بدلاً من العنوان.",
+
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -546,6 +546,16 @@ export const en = {
   "gs.fontsUsedBy": "Imported fonts become available as the interface font.",
   "gs.imported": "imported",
   "gs.remove": "Remove",
+  "gs.nav.sharing": "Sharing",
+  "gs.sharing": "Sharing",
+  "gs.discord": "Discord",
+"gs.discord.hint": "Share what you're reading on Discord",
+"gs.discord.enable": "Show reading activity on Discord",
+"gs.discord.enableHint": "Nothing is sent unless this is on. Requires the Discord desktop app to be running.",
+"gs.discord.showTitle": "Show book title",
+"gs.discord.showChapter": "Show chapter name",
+"gs.discord.showProgress": "Show reading progress",
+"gs.discord.hiddenNote": "Friends will see \"Reading a book\" instead of the title.",
   // RAWY-284: "Book styles", not "Reading defaults". In unified scope this section holds no defaults —
   // the reading-appearance controls moved to the reader, where they preview — so the old title promised
   // something that is not there. "Book styles" is true in BOTH scopes.

--- a/src/lib/discordSettings.ts
+++ b/src/lib/discordSettings.ts
@@ -1,0 +1,70 @@
+// src/lib/discordSettings.ts
+//
+// Discord Rich Presence settings — opt-in master switch plus three fine-grained
+// visibility toggles. Persisted the same way theme/background settings are:
+// a zustand store + settingsGet/settingsSet, loaded once at startup via
+// initDiscordSettings() (called from App.tsx alongside initTheme/initBackground).
+
+import { create } from "zustand";
+import { settingsGet, settingsSet } from "./ipc";
+
+const KEYS = {
+  enabled: "discord_presence_enabled",
+  showTitle: "discord_show_title",
+  showChapter: "discord_show_chapter",
+  showProgress: "discord_show_progress",
+} as const;
+
+interface DiscordSettingsState {
+  ready: boolean;
+  enabled: boolean;
+  showTitle: boolean;
+  showChapter: boolean;
+  showProgress: boolean;
+  setEnabled: (v: boolean) => void;
+  setShowTitle: (v: boolean) => void;
+  setShowChapter: (v: boolean) => void;
+  setShowProgress: (v: boolean) => void;
+}
+
+export const useDiscordSettings = create<DiscordSettingsState>((set) => ({
+  ready: false,
+  enabled: false,
+  // Sub-toggles default ON: once someone opts in to the master switch, showing
+  // title/chapter/progress is the whole point of the feature.
+  showTitle: true,
+  showChapter: true,
+  showProgress: true,
+  setEnabled: (v) => {
+    set({ enabled: v });
+    void settingsSet(KEYS.enabled, v ? "true" : "false");
+  },
+  setShowTitle: (v) => {
+    set({ showTitle: v });
+    void settingsSet(KEYS.showTitle, v ? "true" : "false");
+  },
+  setShowChapter: (v) => {
+    set({ showChapter: v });
+    void settingsSet(KEYS.showChapter, v ? "true" : "false");
+  },
+  setShowProgress: (v) => {
+    set({ showProgress: v });
+    void settingsSet(KEYS.showProgress, v ? "true" : "false");
+  },
+}));
+
+export async function initDiscordSettings(): Promise<void> {
+  const [enabled, showTitle, showChapter, showProgress] = await Promise.all([
+    settingsGet(KEYS.enabled),
+    settingsGet(KEYS.showTitle),
+    settingsGet(KEYS.showChapter),
+    settingsGet(KEYS.showProgress),
+  ]);
+  useDiscordSettings.setState({
+    ready: true,
+    enabled: enabled === "true",
+    showTitle: showTitle !== "false",
+    showChapter: showChapter !== "false",
+    showProgress: showProgress !== "false",
+  });
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -16,6 +16,20 @@ export interface DbHealth {
   schema_version: number;
   tables: string[];
 }
+export async function discordSetReading(
+  title: string,
+  author: string | null,
+  chapter: string | null,
+  progressPct: number | null,
+): Promise<void> {
+  await invoke("discord_set_reading", { title, author, chapter, progressPct });
+}
+export async function discordSetBrowsing(): Promise<void> {
+  await invoke("discord_set_browsing");
+}
+export async function discordClear(): Promise<void> {
+  await invoke("discord_clear");
+}
 
 /** Resolved app-data dir, DB path, and current schema version. */
 export const appInfo = (): Promise<AppInfo> => invoke<AppInfo>("app_info");

--- a/src/reader-engine/discordPresence.ts
+++ b/src/reader-engine/discordPresence.ts
@@ -1,0 +1,109 @@
+// src/reader-engine/discordPresence.ts
+//
+// Watches the reader store AND the Discord settings store, and mirrors the
+// result to Discord Rich Presence via the Rust `discord_set_reading` /
+// `discord_clear` commands. Kept as a separate subscriber rather than baked
+// into store.ts, since the store itself has no other IPC side effects - this
+// stays opt-in and easy to rip out.
+//
+// Two subscriptions feed one `push()`: reader-store changes (page turns,
+// chapter changes, the throttled progress tick) AND settings-store changes
+// (flipping a toggle in the Sharing tab) both need to update Discord - the
+// second one specifically so a toggle takes effect immediately rather than
+// waiting for the next natural reading event.
+//
+// Call initDiscordPresence() once at app startup (e.g. in App.tsx).
+
+import { useReader } from "./store";
+import { discordSetReading, discordClear, discordSetBrowsing } from "../lib/ipc";
+import { useDiscordSettings } from "../lib/discordSettings";
+
+const FRACTION_CHANGE_THRESHOLD = 0.01; // only push on >=1% progress change
+const MIN_UPDATE_INTERVAL_MS = 30_000; // don't spam Discord more than every 30s
+
+let lastBookId: string | null = null;
+let lastFractionSent: number | null = null;
+let lastChapterSent: string | null = null;
+let lastSentAt = 0;
+
+/**
+ * Sends (or clears) presence based on the CURRENT reader + settings state.
+ * `force` bypasses the throttle - used when a settings toggle changes, since
+ * that should take effect immediately rather than waiting for the next
+ * natural reading event.
+ */
+function push(force: boolean): void {
+  const { bookId, bookTitle, chapterLabel, status, fraction } = useReader.getState();
+
+  if (!bookId || status === "idle") {
+    if (lastBookId !== null) {
+      lastBookId = null;
+      lastFractionSent = null;
+      lastChapterSent = null;
+      void discordClear().catch(() => {
+        /* Discord not running - safe to ignore */
+      });
+    }
+    return;
+  }
+
+  if (status !== "ready" || !bookTitle) return;
+
+  const now = Date.now();
+  const bookChanged = bookId !== lastBookId;
+  const chapterChanged = chapterLabel !== lastChapterSent;
+  const fractionMoved =
+    lastFractionSent === null ||
+    Math.abs(fraction - lastFractionSent) >= FRACTION_CHANGE_THRESHOLD;
+  const enoughTimePassed = now - lastSentAt >= MIN_UPDATE_INTERVAL_MS;
+
+  if (!force && !bookChanged && !chapterChanged && !(fractionMoved && enoughTimePassed)) return;
+
+  lastBookId = bookId;
+  lastFractionSent = fraction;
+  lastChapterSent = chapterLabel;
+  lastSentAt = now;
+
+  const { showTitle, showChapter, showProgress } = useDiscordSettings.getState();
+
+  const title = showTitle ? bookTitle : "a book";
+  const chapter = showChapter ? chapterLabel : null;
+  const progressPct = showProgress ? Math.round(fraction * 100) : null;
+
+  void discordSetReading(title, null, chapter, progressPct).catch(() => {
+    /* Discord not running - safe to ignore */
+  });
+}
+
+export function initDiscordPresence(): () => void {
+  const unsubReader = useReader.subscribe(() => push(false));
+
+  // Any Sharing-tab toggle change re-sends immediately (force=true), so
+  // turning "Show progress" off, for example, clears the stale "0%" right
+  // away instead of waiting for the next page turn or the 30s throttle.
+  const unsubSettings = useDiscordSettings.subscribe(() => push(true));
+
+  return () => {
+    unsubReader();
+    unsubSettings();
+  };
+}
+
+/**
+ * Call at the definite moment a book is closed (e.g. Reader's onExit).
+ * Shows "Browsing the library" instead of going fully blank, but respects
+ * the master switch - if presence sharing is off, this is a no-op.
+ * Also resets the internal dedup trackers so re-opening the same book is
+ * treated as a fresh session rather than a no-op.
+ */
+export function showBrowsingPresence(): void {
+  lastBookId = null;
+  lastFractionSent = null;
+  lastChapterSent = null;
+
+  if (!useDiscordSettings.getState().enabled) return;
+
+  void discordSetBrowsing().catch(() => {
+    /* Discord not running - safe to ignore */
+  });
+}


### PR DESCRIPTION
A simple feature I made to show my friends on Discord what I'm currently reading.

<img width="449" height="177" alt="image" src="https://github.com/user-attachments/assets/b2bcce86-fa4e-462f-a0e4-7695eecc96e7" />
<img width="449" height="177" alt="image" src="https://github.com/user-attachments/assets/1c75bc53-15c6-47d6-ba3f-2f0c5459b417" />

It shows:
- Book title
- Chapter title
- Progress percentage %

From a friend's perspective:

<img width="430" height="241" alt="image" src="https://github.com/user-attachments/assets/32598f65-2355-49b9-92c0-c92b92183294" />

Friends can see a button, "Get Sard", linked to the GitHub page.

It can be configured through Settings (off by default):

<img width="966" height="658" alt="image" src="https://github.com/user-attachments/assets/6a3f4246-738a-46d1-b692-9e965aa38031" />

## What changed

- New Rust module `discord_rpc.rs` (via the `discord-rich-presence` crate) managing a lazily-connected, reconnecting Discord IPC client
- Three new IPC commands: `discord_set_reading`, `discord_set_browsing`, `discord_clear`
- New "Sharing" tab in Settings, with a master on/off switch (default **off**) plus three sub-toggles for title/chapter/progress visibility — all persisted via the existing settings store
- New frontend subscriber (`discordPresence.ts`) that watches the reader store and pushes throttled updates (max once per 30s / 1% progress change, hard floor of 2s between any two sends to guard against runaway update loops)

## Testing

- `cargo test` — 109/109 passing
- `cargo clippy --all-targets` — no new warnings (all 13 pre-existing, unrelated files)
- `npm run build` — clean typecheck + build

## ⚠️ Before merging

`DISCORD_APP_ID` in `discord_rpc.rs` is a placeholder — you'll need to create a Discord Application at https://discord.com/developers/applications, name it Sard and upload the logo image. then copy the ID.

<img width="1018" height="147" alt="image" src="https://github.com/user-attachments/assets/93948f27-c596-435a-8026-353e3434efa9" />