### PR TITLE
Compile and run the Rust tests in CI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -41,6 +41,30 @@ jobs:
       - name: Typecheck
         run: npx tsc --noEmit -p tsconfig.json
 
+      # THE RUST SIDE WAS NEVER CHECKED BY CI AT ALL — not compiled, not tested, not once. The cost of
+      # that was measured rather than guessed: `src/books/mod.rs` declared a module whose file had been
+      # removed with the public/private split, so `cargo test` failed to COMPILE and every one of the
+      # 102 Rust tests had been silently absent for as long as the declaration had been wrong. Nothing
+      # reported it, because nothing ran it.
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+
+      # --locked, so a pull request that quietly needs a different dependency graph fails here rather
+      # than resolving to something nobody chose. --all-targets reaches the binary and the test target,
+      # neither of which `cargo test` alone would compile.
+      - name: Cargo check
+        working-directory: src-tauri
+        run: cargo check --all-targets --locked
+
+      - name: Cargo test
+        working-directory: src-tauri
+        run: cargo test --locked
+
       # The EPUB fixtures are generated, not committed: `.gitignore` excludes tests/fixtures/epub/ so
       # the repository carries the generator rather than opaque binary blobs. That means a clean
       # checkout has none of them, and the suites that read a fixture fail with ENOENT — which is
@@ -73,3 +97,57 @@ jobs:
       - name: Production-build gate
         shell: bash
         run: node scripts/verify-main-buildable.mjs --ref="$PROD_TREE"
+
+  # A SECOND PLATFORM, COMPILED. The job above runs on windows-latest, so `#[cfg(not(target_os =
+  # "windows"))]` code is never compiled by it — the arm that exists precisely because the other
+  # platforms need something different is the arm CI cannot see. `webview_chrome.rs` and
+  # `window_chrome.rs` already carry such arms, and the reader-host work will add more.
+  #
+  # Compilation only. No tests that need a display, no bundling, no artifact: this answers "does the
+  # non-Windows arm still build" and deliberately nothing else, so it stays fast and has one meaning
+  # when it fails.
+  rust-linux:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Pinned to match the job above rather than taking whatever the runner image ships, so the two
+      # jobs cannot build the bundle with different toolchains.
+      - name: Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+
+      # Tauri links against the system WebKitGTK on Linux; without these the crate does not configure.
+      - name: System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev patchelf libssl-dev \
+            libayatana-appindicator3-dev build-essential
+
+      # `tauri::generate_context!` reads `frontendDist`, so the directory has to exist before the crate
+      # will compile. The bundle's CONTENTS are irrelevant to a compile check — only its presence is —
+      # so this builds the real one rather than inventing a stub that could drift from it.
+      - name: Frontend bundle
+        run: |
+          npm ci
+          npm run build
+
+      - name: Cargo check
+        working-directory: src-tauri
+        run: cargo check --all-targets --locked
+
+      - name: Cargo test
+        working-directory: src-tauri
+        run: cargo test --locked

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,11 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+# Visual Studio's workspace cache. `*.suo` below covers one file inside it; the directory itself was
+# not listed, so `git add -A` staged the whole thing — including DocumentLayout.json, which records
+# the absolute path of the machine it was opened on. The production-content gate refused the tree
+# over exactly that, which is the gate working. Ignoring the directory stops it recurring.
+.vs/
 .idea
 .DS_Store
 *.suo
@@ -78,6 +83,10 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Python bytecode from the local probe/measurement scripts.
+__pycache__/
+*.pyc
 
 # No archives in public/. Vite copies public/ verbatim into dist/ and Tauri embeds dist/ into the
 # executable, so a stray archive here is compiled into every build and inflates every artifact.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,10 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [features]
 default = []
 diag = []
+# Compiles `books::corpus_tests`, whose source ships only with the private workspace because the book
+# corpus it reads is not distributed. Off by default so a tree without that file still builds its
+# test target; the workspace that has it runs `cargo test --features corpus-tests`.
+corpus-tests = []
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/src/books/mod.rs
+++ b/src-tauri/src/books/mod.rs
@@ -12,7 +12,16 @@
 
 pub mod compat;
 
-#[cfg(test)]
+// The corpus tests read a book corpus that is not distributed, so `corpus_tests.rs` exists only in
+// the private workspace — it was dropped when the public tree was split out, while this declaration
+// was left behind. `mod` cannot be made conditional on a file existing, so an unqualified
+// declaration made `cargo test` fail to COMPILE in every tree that lacks the file: not one Rust test
+// could run anywhere, including the 102 that have nothing to do with the corpus.
+//
+// A feature gate is used rather than deleting the line, because the two trees share this file
+// byte-for-byte; deleting it here would diverge them and the breakage would return on the next sync.
+// The workspace that has the corpus runs them with `--features corpus-tests`.
+#[cfg(all(test, feature = "corpus-tests"))]
 mod corpus_tests;
 #[cfg(test)]
 mod wp2_tests;

--- a/src-tauri/src/books/wp2_tests.rs
+++ b/src-tauri/src/books/wp2_tests.rs
@@ -149,8 +149,19 @@ struct Imported {
     provenance: Option<String>,
 }
 
+/// Distinguishes two calls that build the SAME bytes. The working directory used to be keyed on the
+/// EPUB's hash alone, and several cases here import a byte-identical `Build::default()` book — so
+/// two of them landed on one directory and, running on separate threads as cargo does by default,
+/// one called `remove_dir_all` while the other was mid-import. The loser read no row back and saw
+/// every column as `None`, which reads exactly like a product bug in whichever assertion got there
+/// first. It surfaced as `spine_fragmented: None` where `Some(0)` was expected, and it did not
+/// reproduce on the next run. The counter makes each call's directory its own.
+static IMPORT_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 fn import(bytes: &[u8], filename: &str) -> Imported {
-    let base = std::env::temp_dir().join(format!("sard_wp2_{}", &hex_sha256(bytes)[..16]));
+    let seq = IMPORT_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let base = std::env::temp_dir()
+        .join(format!("sard_wp2_{seq}_{filename}_{}", &hex_sha256(bytes)[..16]));
     let _ = std::fs::remove_dir_all(&base);
     std::fs::create_dir_all(base.join("src")).unwrap();
     let src = base.join("src").join(format!("{filename}.epub"));


### PR DESCRIPTION
CI never invoked cargo. There was no Rust step in either workflow, so nothing noticed that `cargo test` had stopped compiling: `books/mod.rs` declared `corpus_tests`, whose file left with the public/private tree split, and a `mod` cannot be conditional on a file existing.

**102 lib tests and 9 integration tests had not run anywhere for as long as that declaration had been wrong.**

## What changed

| File | Change |
|---|---|
| `src-tauri/src/books/mod.rs` | `corpus_tests` moves behind a `corpus-tests` feature |
| `src-tauri/Cargo.toml` | declares that feature, off by default |
| `src-tauri/src/books/wp2_tests.rs` | fixes a flaky test's directory collision |
| `.github/workflows/pr-checks.yml` | `cargo check` + `cargo test` on Windows; a new Linux compile job |

A feature gate rather than a deletion: both trees share `mod.rs` byte-for-byte and the corpus source still exists in the workspace that has the book corpus, so deleting the line here would diverge them and bring the breakage back on the next sync. That workspace runs `--features corpus-tests`.

## The flake compiling the tests exposed

`wp2_tests::import` derived its working directory from the EPUB's hash alone, and several cases import a byte-identical default book. Two of them shared a directory and — on separate threads, as cargo runs them — one wiped it while the other was mid-import. The loser read no row back and saw every column as `None`, which looks exactly like a product bug in whichever assertion arrived first. It failed as `spine_fragmented: None`, then passed on the next run.

A sequence number gives each call its own directory. The suite now survives eight consecutive parallel runs.

## Linux job

The existing job is `windows-latest`, so `#[cfg(not(target_os = "windows"))]` was never compiled anywhere — the arm that exists because other platforms need something different is precisely the arm nothing could see. Compilation only: no display, no bundling, no artifact.

## Deliberately not included

`cargo fmt --check` and `cargo clippy -D warnings` are not gates. `build.rs` is not rustfmt-clean and clippy reports ten warnings, all pre-existing; adopting either would mean reformatting unrelated code in this change. Worth a separate decision.

## Verification

- `cargo check --all-targets --locked` — clean
- `cargo test --locked` — 102 + 9 pass, 8/8 consecutive parallel runs clean
- `npm test` — 309 passed / 11 skipped, unchanged
- `verify:main-buildable` — PASS
- No diff under `src/` or `public/`: no frontend, no reader engine, no foliate-js
- Every non-comment Rust edit is `#[cfg(test)]`-gated. No product logic changed.