### PR TITLE
Reader-host origin: an isolated origin for book content on WebKit

### DIFF
--- a/public/reader-host/host.js
+++ b/public/reader-host/host.js
@@ -1,0 +1,114 @@
+// The reader host, step 1.
+//
+// The origin exists and carries its policy; nothing reads a book here yet. The engine, the byte
+// transfer, the section sandbox change and the message channel are later steps, each with its own
+// evidence gate, and none of them is present.
+//
+// `?selfcheck=1` runs the acceptance checks for this step and writes them into #report. Without it
+// the document is inert, so the checks are a deliberate act rather than something that runs behind
+// a reader every time a book opens.
+(function () {
+  "use strict";
+
+  var params = new URLSearchParams(location.search);
+  if (params.get("selfcheck") !== "1") return;
+
+  var R = {
+    origin: location.origin,
+    href: location.href,
+    // A book section will eventually live here; right now the only thing to record is that this
+    // document itself cannot see the application.
+    reach: {},
+    assets: {},
+    cspViolations: [],
+    channels: {}
+  };
+
+  // A CSP refusal raises this; a CORS or same-origin-policy refusal does not. It is the only way to
+  // name which layer said no, and the previous study was retracted for guessing.
+  addEventListener("securitypolicyviolation", function (e) {
+    R.cspViolations.push({
+      directive: e.violatedDirective,
+      blocked: String(e.blockedURI).slice(0, 120)
+    });
+    write();
+  });
+
+  function write() {
+    document.getElementById("report").textContent = JSON.stringify(R, null, 1);
+  }
+
+  function attempt(name, fn) {
+    try {
+      var v = fn();
+      R.reach[name] = v === undefined ? "undefined" : "REACHED:" + (typeof v);
+    } catch (e) {
+      R.reach[name] = "BLOCKED:" + (e && e.name ? e.name : "Error");
+    }
+  }
+
+  // What can this origin see of the application that embeds it? Everything here must be refused.
+  attempt("parent.__TAURI_INTERNALS__", function () { return window.parent.__TAURI_INTERNALS__; });
+  attempt("top.__TAURI_INTERNALS__", function () { return window.top.__TAURI_INTERNALS__; });
+  attempt("parent.document", function () { return window.parent.document; });
+  attempt("top.document", function () { return window.top.document; });
+  attempt("parent.location.href", function () { return window.parent.location.href; });
+  attempt("window.__TAURI_INTERNALS__ (own)", function () { return window.__TAURI_INTERNALS__; });
+  attempt("window.__TAURI__ (own)", function () { return window.__TAURI__; });
+
+  // No channel is created in this step, and none should exist. Recorded so that the absence is a
+  // measured fact rather than an assumption, and so a later step cannot quietly introduce one.
+  R.channels.messagePortsOnGlobal = (function () {
+    var hits = [];
+    for (var k in window) {
+      try { if (window[k] instanceof MessagePort) hits.push(k); } catch (e) { /* ignore */ }
+    }
+    return hits.length ? hits.join(",") : "none";
+  })();
+  R.channels.opener = window.opener ? "PRESENT" : "null";
+
+  write();
+
+  function record(key, promise) {
+    return promise.then(
+      function (v) { R.assets[key] = v; },
+      function (e) { R.assets[key] = "FAIL:" + (e && e.name ? e.name : "Error"); }
+    ).then(write);
+  }
+
+  // The assets this origin must be able to serve, checked against the real handler.
+  var font = "/fonts/Amiri-Regular.ttf";
+  var cmap = "/pdfjs/cmaps/UniJIS-UCS2-H.bcmap";
+
+  Promise.all([
+    record("fetch.font", fetch(font).then(function (r) {
+      return r.ok ? r.arrayBuffer().then(function (b) { return "OK:" + r.status + " bytes=" + b.byteLength; })
+                  : "HTTP:" + r.status;
+    })),
+    record("fetch.pdfjsCmap", fetch(cmap).then(function (r) {
+      return r.ok ? r.arrayBuffer().then(function (b) { return "OK:" + r.status + " bytes=" + b.byteLength; })
+                  : "HTTP:" + r.status;
+    })),
+    record("fetch.pdfjsWorker", fetch("/pdfjs/pdf.worker.mjs").then(function (r) { return "OK:" + r.status; })),
+    // Must be refused: this origin has no route to a book, by construction.
+    record("fetch.refusedBookPath", fetch("/library/book.epub").then(function (r) { return "HTTP:" + r.status; })),
+    record("fetch.refusedTraversal", fetch("/fonts/../../sard.db").then(function (r) { return "HTTP:" + r.status; })),
+    // Must be refused by connect-src: a different origin.
+    record("fetch.crossOrigin", fetch("http://127.0.0.1:9/none").then(function (r) { return "OK:" + r.status; })),
+
+    // Whether the font is merely FETCHABLE or actually USABLE as a face are different questions.
+    // `connect-src 'self'` governs the first; `font-src` governs the second, and this policy sets
+    // no `font-src`, so it falls back to `default-src 'none'`. Measured rather than predicted.
+    (function () {
+      if (!("FontFace" in window)) { R.assets["fontFace.load"] = "UNKNOWN:no FontFace API"; return Promise.resolve(); }
+      var face = new FontFace("SardHostProbe", "url(" + font + ")");
+      return face.load().then(
+        function () { R.assets["fontFace.load"] = "LOADED"; },
+        function (e) { R.assets["fontFace.load"] = "FAIL:" + (e && e.name ? e.name : "Error"); }
+      ).then(write);
+    })()
+  ]).then(function () {
+    R.done = true;
+    write();
+  });
+})();

--- a/public/reader-host/index.html
+++ b/public/reader-host/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Sard reader host</title>
+<!-- The reader-host origin. Step 1 establishes the origin and its policy; the reading engine moves
+     in later, and this body is what it replaces.
+
+     There is no inline script anywhere in this document on purpose: the policy this origin ships
+     under is `script-src 'self'`, so an inline block would be refused. If one ever appears here and
+     the page still works, the policy has stopped being applied and that is a defect, not a
+     convenience. -->
+<style>
+  html, body { margin: 0; height: 100%; background: #f7f2e8; }
+  #report { position: absolute; left: -9999px; top: -9999px; width: 1px; height: 1px;
+            overflow: hidden; pointer-events: none; white-space: pre; }
+</style>
+</head>
+<body>
+  <div id="stage"></div>
+  <pre id="report"></pre>
+  <script src="/host.js"></script>
+</body>
+</html>

--- a/src-tauri/src/bookhost.rs
+++ b/src-tauri/src/bookhost.rs
@@ -38,6 +38,36 @@ pub const SCHEME: &str = "sardhost";
 
 /// The policy this origin ships under.
 ///
+/// SHAPE: `default-src 'none'` plus an explicit allowance per resource kind. That default is the
+/// point — a directive nobody thought about fails closed rather than inheriting something permissive.
+/// It is also the trap: an OMITTED directive falls back to `'none'`, so every kind of resource a book
+/// legitimately loads has to be named here or the reader silently renders nothing. The first draft of
+/// this policy named only `script-src`, `style-src` and `connect-src`, which meant `img-src`,
+/// `font-src`, `media-src` and `frame-src` all resolved to `'none'` — that policy could not have
+/// displayed a single image, loaded a single face, or even created the section iframe.
+///
+/// PRINCIPLE: the content-loading directives MIRROR the application CSP in `tauri.conf.json`, because
+/// today the book document inherits that policy; matching it is what keeps rendering behaviour
+/// identical. The privilege directives (`default-src`, `script-src`, `connect-src`) are STRICTER than
+/// the application's. Same content capability, less privilege — never the reverse. Anything wider
+/// than the application policy would be an expansion of what a book can reach, which this origin
+/// exists to prevent.
+///
+/// Per directive:
+/// - `script-src 'self'` — the host bootstrap and the engine, served from this origin only.
+/// - `style-src` — `'unsafe-inline'` and `blob:` because foliate rewrites book stylesheets into blobs
+///   and Sard injects its reading CSS inline; identical to the application policy.
+/// - `img-src` — `blob:`/`data:` carry EPUB images (foliate blobs them) and the PDF page canvas, which
+///   `pdf.js` copies to an `<img>` via `toDataURL` (VENDOR patch 4, RAWY-85). `asset:` carries images
+///   that live in app data.
+/// - `font-src` — `'self'` for the bundled faces served at `/fonts/*`, `blob:`/`data:` for faces
+///   embedded in the book, and `asset:` for USER-INSTALLED fonts: `fonts.ts:95` builds
+///   `@font-face { src: url(convertFileSrc(...)) }` and `FoliateController::writeFonts` writes that
+///   sheet into each content document. Without `asset:` every custom font silently disappears.
+/// - `media-src blob:` — exactly the application's value, no wider.
+/// - `frame-src 'self' blob:` — the paginator CREATES the section iframe from this document. Omit
+///   this and the reader has no iframe to render into at all.
+///
 /// `connect-src 'self'` is required rather than `'none'`: pdf.js fetches its own stylesheets
 /// (`pdf.js:10,13` call `fetchText(pdfjsPath(...))`), so a blanket refusal would break the PDF path.
 ///
@@ -45,9 +75,17 @@ pub const SCHEME: &str = "sardhost";
 /// CORS-permissive third origin both fail and both raise a `connect-src` violation, while a
 /// same-origin fetch succeeds. A WebSocket to another origin throws `SecurityError` with the same
 /// violation. Enforcement on WKWebView and WebView2 is UNKNOWN and must be measured there.
+///
+/// UNKNOWN, and NOT decided by this policy: whether an `asset:` response is CORS-readable as a FONT
+/// from this origin. CSP permitting a load is not the same as the fetch succeeding — a CORS refusal
+/// has a different signature (no `securitypolicyviolation` event) and must be measured separately.
 const CSP: &str = "default-src 'none'; \
                    script-src 'self'; \
                    style-src 'self' 'unsafe-inline' blob:; \
+                   img-src 'self' asset: http://asset.localhost https://asset.localhost blob: data:; \
+                   font-src 'self' asset: http://asset.localhost https://asset.localhost blob: data:; \
+                   media-src blob:; \
+                   frame-src 'self' blob:; \
                    connect-src 'self'";
 
 /// Map a request path onto a bundle path, or refuse.
@@ -214,11 +252,128 @@ mod tests {
         }
     }
 
+    /// Split a CSP into `directive -> value`, so a test can reason about one directive at a time
+    /// instead of substring-matching the whole string. Substring matching is what let the missing
+    /// directives through: asserting what IS present can never notice what is absent.
+    fn directives(csp: &str) -> std::collections::HashMap<String, String> {
+        csp.split(';')
+            .filter_map(|part| {
+                let part = part.trim();
+                if part.is_empty() {
+                    return None;
+                }
+                let (name, value) = part.split_once(char::is_whitespace)?;
+                Some((
+                    name.to_ascii_lowercase(),
+                    value.split_whitespace().collect::<Vec<_>>().join(" "),
+                ))
+            })
+            .collect()
+    }
+
+    fn app_csp() -> String {
+        let raw = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json"),
+        )
+        .expect("tauri.conf.json is readable");
+        let conf: serde_json::Value = serde_json::from_str(&raw).expect("tauri.conf.json parses");
+        conf["app"]["security"]["csp"]
+            .as_str()
+            .expect("the application CSP is a string")
+            .to_string()
+    }
+
     #[test]
     fn csp_is_the_policy_that_was_measured() {
-        assert!(CSP.contains("default-src 'none'"));
-        assert!(CSP.contains("script-src 'self'"));
-        assert!(CSP.contains("style-src 'self' 'unsafe-inline' blob:"));
-        assert!(CSP.contains("connect-src 'self'"));
+        let d = directives(CSP);
+        assert_eq!(d.get("default-src").map(String::as_str), Some("'none'"));
+        assert_eq!(d.get("script-src").map(String::as_str), Some("'self'"));
+        assert_eq!(d.get("connect-src").map(String::as_str), Some("'self'"));
+    }
+
+    /// `default-src 'none'` means an OMITTED directive resolves to `'none'`. Every resource kind the
+    /// reader actually loads must therefore be named explicitly. This is the test the first draft of
+    /// the policy did not have: it shipped without `img-src`, `font-src`, `media-src` or `frame-src`,
+    /// so it could not have rendered an image, loaded a custom face, or created the section iframe —
+    /// and the assertions of the day, which only checked that four directives were PRESENT, all passed.
+    #[test]
+    fn every_resource_kind_the_reader_loads_is_named_explicitly() {
+        let d = directives(CSP);
+        for required in ["style-src", "img-src", "font-src", "media-src", "frame-src"] {
+            assert!(
+                d.contains_key(required),
+                "{required} is absent, so it falls back to default-src 'none' and that resource \
+                 kind cannot load at all"
+            );
+        }
+    }
+
+    /// The content-loading directives must MIRROR the application policy, in both directions.
+    ///
+    /// Narrower than the application = the reader renders differently here than it does today, which
+    /// is the behaviour change this whole origin is supposed to avoid. Wider = a book reaches
+    /// something it cannot currently reach, which is the security property this origin exists for.
+    /// Equality is the only value that satisfies both, so the test asserts equality rather than
+    /// containment and reads the application policy from `tauri.conf.json` rather than duplicating it.
+    #[test]
+    fn content_directives_mirror_the_application_policy() {
+        let host = directives(CSP);
+        let app = directives(&app_csp());
+        for kind in ["style-src", "img-src", "font-src", "media-src", "frame-src"] {
+            let a = app.get(kind).unwrap_or_else(|| panic!("app CSP declares {kind}"));
+            let h = host.get(kind).unwrap_or_else(|| panic!("host CSP declares {kind}"));
+            assert_eq!(h, a, "{kind} must match the application policy exactly");
+        }
+    }
+
+    /// Proof that the guard above can actually fail.
+    ///
+    /// An assertion that passes on correct input tells you nothing until you have seen it reject bad
+    /// input. This replays the EXACT policy that shipped in the first draft and shows the check
+    /// rejecting it — so the guard is known to bite, not merely known to pass. Keeping the defective
+    /// string here as a fixture also documents the mistake precisely, which a comment cannot.
+    #[test]
+    fn the_guard_rejects_the_defective_first_draft() {
+        const FIRST_DRAFT: &str = "default-src 'none'; \
+                                   script-src 'self'; \
+                                   style-src 'self' 'unsafe-inline' blob:; \
+                                   connect-src 'self'";
+        let d = directives(FIRST_DRAFT);
+        let missing: Vec<&str> = ["style-src", "img-src", "font-src", "media-src", "frame-src"]
+            .into_iter()
+            .filter(|k| !d.contains_key(*k))
+            .collect();
+        assert_eq!(
+            missing,
+            vec!["img-src", "font-src", "media-src", "frame-src"],
+            "the first draft omitted exactly these four, and the guard must notice every one"
+        );
+        // And the policy in force must not be that string.
+        assert_ne!(CSP, FIRST_DRAFT);
+    }
+
+    /// The privilege directives must be STRICTER than the application's, never merely equal.
+    #[test]
+    fn privilege_directives_are_stricter_than_the_application() {
+        let host = directives(CSP);
+        let app = directives(&app_csp());
+        assert_eq!(host.get("default-src").map(String::as_str), Some("'none'"));
+        assert_ne!(
+            app.get("default-src").map(String::as_str),
+            Some("'none'"),
+            "if the application ever tightens to 'none' this comparison stops meaning anything"
+        );
+        let app_connect = app.get("connect-src").expect("app CSP declares connect-src");
+        let host_connect = host.get("connect-src").expect("host CSP declares connect-src");
+        assert!(
+            host_connect.split_whitespace().count() < app_connect.split_whitespace().count(),
+            "host connect-src ({host_connect}) must be narrower than the app's ({app_connect})"
+        );
+        for forbidden in ["ipc:", "http://ipc.localhost"] {
+            assert!(
+                !host_connect.contains(forbidden),
+                "the host origin must never be able to reach {forbidden}"
+            );
+        }
     }
 }

--- a/src-tauri/src/bookhost.rs
+++ b/src-tauri/src/bookhost.rs
@@ -1,0 +1,224 @@
+//! The reader-host ORIGIN — step 1 of the origin-isolation work.
+//!
+//! # Why this exists
+//!
+//! Measured on WebKitGTK 2.52.3: the browser delivers no pointer, wheel or key events into an
+//! iframe whose scripts are disabled. Sard's book frame carries `sandbox="allow-same-origin"` and
+//! nothing else (`paginator.js:252`), so on WebKit the reader receives no input at all. Enabling
+//! scripts fixes that, and — measured in the same matrix — immediately hands book content
+//! `window.parent.__TAURI_INTERNALS__`, the app document and app globals when the book shares the
+//! application's origin.
+//!
+//! No sandbox configuration provides all three of: the driving code can read the section document,
+//! real input arrives, and privileged surfaces stay unreachable. The boundary therefore has to move
+//! rather than the book: the reading engine will run in THIS origin, which holds no Tauri API, and
+//! the application stays outside it.
+//!
+//! # What step 1 does, and deliberately does not do
+//!
+//! This module serves a static, allow-listed bundle from an isolated origin. It does not move
+//! foliate-js, does not transfer book bytes, does not add `allow-scripts`, and creates no
+//! communication channel. Those are later steps and each has its own evidence gate.
+//!
+//! # Why the asset resolver, and not the filesystem
+//!
+//! Every response comes from `AssetResolver`, which reads the FRONTEND BUNDLE compiled into the
+//! binary. It has no notion of a filesystem path, so this handler **structurally cannot** serve a
+//! book, a database, or anything else on disk — there is no code path that could be pointed at one.
+//! That is a stronger guarantee than validating paths would be, and it is the reason for the choice.
+
+use std::borrow::Cow;
+
+use tauri::http::{header, Request, Response, StatusCode};
+use tauri::{Runtime, UriSchemeContext};
+
+/// The scheme. Resolves to a distinct origin on every supported webview, which is the entire point:
+/// `http://sardhost.localhost` on WebView2, `sardhost://localhost` on WebKitGTK and WKWebView.
+pub const SCHEME: &str = "sardhost";
+
+/// The policy this origin ships under.
+///
+/// `connect-src 'self'` is required rather than `'none'`: pdf.js fetches its own stylesheets
+/// (`pdf.js:10,13` call `fetchText(pdfjsPath(...))`), so a blanket refusal would break the PDF path.
+///
+/// MEASURED, WebKitGTK only: with this policy a fetch to the application origin and to a
+/// CORS-permissive third origin both fail and both raise a `connect-src` violation, while a
+/// same-origin fetch succeeds. A WebSocket to another origin throws `SecurityError` with the same
+/// violation. Enforcement on WKWebView and WebView2 is UNKNOWN and must be measured there.
+const CSP: &str = "default-src 'none'; \
+                   script-src 'self'; \
+                   style-src 'self' 'unsafe-inline' blob:; \
+                   connect-src 'self'";
+
+/// Map a request path onto a bundle path, or refuse.
+///
+/// An allow-list, not a sanitiser: anything not named here has no route at all. A rejected path is
+/// rejected because it was never listed, so there is no traversal to defeat.
+fn resolve(path: &str) -> Option<String> {
+    // Refuse traversal shapes outright, even though the allow-list below would already reject them.
+    // Two independent reasons to say no is the cheap kind of defence.
+    if path.contains("..") || path.contains('\\') || path.contains("//") {
+        return None;
+    }
+    let p = path.split('?').next().unwrap_or(path);
+    match p {
+        "" | "/" | "/index.html" => Some("reader-host/index.html".into()),
+        "/host.js" => Some("reader-host/host.js".into()),
+        _ => {
+            if let Some(name) = p.strip_prefix("/fonts/") {
+                // Bundled faces only. `absFontUrl` (injectedCss.ts:179) pins @font-face to
+                // `location.origin`, so once the engine runs here these must resolve here.
+                return safe_segment(name, &["ttf", "otf", "woff", "woff2"])
+                    .map(|n| format!("fonts/{n}"));
+            }
+            if let Some(rest) = p.strip_prefix("/pdfjs/") {
+                // pdf.js resolves cmaps, standard fonts and its worker against `import.meta.url`
+                // (`pdf.js:1`), so they must be reachable from this origin too.
+                return safe_path(rest, &["bcmap", "mjs", "js", "css", "pfb", "ttf", "otf", "json"])
+                    .map(|r| format!("foliate-js/vendor/pdfjs/{r}"));
+            }
+            None
+        }
+    }
+}
+
+/// One path segment, conservative character set, extension on the list.
+fn safe_segment(name: &str, exts: &[&str]) -> Option<String> {
+    if name.is_empty()
+        || name.contains('/')
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+    {
+        return None;
+    }
+    let ext = name.rsplit_once('.')?.1.to_ascii_lowercase();
+    exts.contains(&ext.as_str()).then(|| name.to_string())
+}
+
+/// The same rule, but permitting a single directory level (`cmaps/…`, `standard_fonts/…`).
+fn safe_path(rest: &str, exts: &[&str]) -> Option<String> {
+    let mut parts = rest.split('/');
+    let first = parts.next()?;
+    match parts.next() {
+        None => safe_segment(first, exts),
+        Some(name) if parts.next().is_none() => {
+            let dir_ok = !first.is_empty()
+                && first
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-'));
+            if !dir_ok {
+                return None;
+            }
+            safe_segment(name, exts).map(|n| format!("{first}/{n}"))
+        }
+        _ => None, // deeper than the bundle needs
+    }
+}
+
+fn mime_for(path: &str) -> &'static str {
+    match path.rsplit_once('.').map(|(_, e)| e.to_ascii_lowercase()).as_deref() {
+        Some("html") => "text/html; charset=utf-8",
+        Some("js") | Some("mjs") => "text/javascript; charset=utf-8",
+        Some("css") => "text/css; charset=utf-8",
+        Some("json") => "application/json; charset=utf-8",
+        Some("ttf") => "font/ttf",
+        Some("otf") => "font/otf",
+        Some("woff") => "font/woff",
+        Some("woff2") => "font/woff2",
+        Some("bcmap") => "application/octet-stream",
+        _ => "application/octet-stream",
+    }
+}
+
+fn refuse(status: StatusCode) -> Response<Cow<'static, [u8]>> {
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(Cow::Borrowed(b"" as &[u8]))
+        .expect("static response")
+}
+
+/// Serve one request from the compiled frontend bundle, or refuse it.
+pub fn handle<R: Runtime>(
+    ctx: UriSchemeContext<'_, R>,
+    request: Request<Vec<u8>>,
+) -> Response<Cow<'static, [u8]>> {
+    if request.method() != tauri::http::Method::GET {
+        return refuse(StatusCode::METHOD_NOT_ALLOWED);
+    }
+    let path = request.uri().path().to_string();
+    let Some(asset_path) = resolve(&path) else {
+        return refuse(StatusCode::NOT_FOUND);
+    };
+    let Some(asset) = ctx.app_handle().asset_resolver().get(asset_path.clone()) else {
+        return refuse(StatusCode::NOT_FOUND);
+    };
+
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, mime_for(&asset_path))
+        // No cross-origin reader is wanted: this origin exists to be isolated, not shared.
+        .header("Cross-Origin-Resource-Policy", "same-origin")
+        .header("X-Content-Type-Options", "nosniff");
+    if asset_path.ends_with(".html") {
+        builder = builder.header(header::CONTENT_SECURITY_POLICY, CSP);
+    }
+    builder
+        .body(Cow::Owned(asset.bytes))
+        .unwrap_or_else(|_| refuse(StatusCode::INTERNAL_SERVER_ERROR))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serves_only_the_allow_listed_bundle() {
+        assert_eq!(resolve("/").as_deref(), Some("reader-host/index.html"));
+        assert_eq!(resolve("/index.html").as_deref(), Some("reader-host/index.html"));
+        assert_eq!(resolve("/host.js").as_deref(), Some("reader-host/host.js"));
+        assert_eq!(resolve("/fonts/Amiri-Regular.ttf").as_deref(), Some("fonts/Amiri-Regular.ttf"));
+        assert_eq!(
+            resolve("/pdfjs/cmaps/UniJIS-UCS2-H.bcmap").as_deref(),
+            Some("foliate-js/vendor/pdfjs/cmaps/UniJIS-UCS2-H.bcmap")
+        );
+    }
+
+    #[test]
+    fn refuses_everything_else() {
+        for p in [
+            "/../../etc/passwd",
+            "/fonts/../../secret",
+            "/fonts/sub/dir/x.ttf",
+            "/fonts/book.epub",
+            "/pdfjs/../../../epub.js",
+            "/foliate-js/view.js",
+            "/library/book.epub",
+            "/sard.db",
+            "//evil",
+            "/fonts/",
+            "/host.js.map",
+        ] {
+            assert!(resolve(p).is_none(), "should refuse {p}");
+        }
+    }
+
+    /// The guarantee that matters: no request shape names a filesystem location. Every accepted
+    /// path maps into the compiled bundle, so a book on disk has no route through this origin.
+    #[test]
+    fn no_accepted_path_escapes_the_bundle() {
+        for p in ["/", "/index.html", "/host.js", "/fonts/Amiri-Regular.ttf", "/pdfjs/pdf.worker.mjs"] {
+            let mapped = resolve(p).expect("allow-listed");
+            assert!(!mapped.starts_with('/') && !mapped.contains(".."), "{p} -> {mapped}");
+        }
+    }
+
+    #[test]
+    fn csp_is_the_policy_that_was_measured() {
+        assert!(CSP.contains("default-src 'none'"));
+        assert!(CSP.contains("script-src 'self'"));
+        assert!(CSP.contains("style-src 'self' 'unsafe-inline' blob:"));
+        assert!(CSP.contains("connect-src 'self'"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,10 @@ pub mod books; // file import, format detection, EPUB/PDF orchestration (placeho
 pub mod metadata; // read embedded metadata + persist user overrides (placeholder)
 pub mod fonts; // register/validate custom fonts (placeholder)
 pub mod photocards; // saved photo cards: PNG store + DB rows (RAWY-52, Photo Mode part 2a)
-pub mod bookhost; // the isolated reader-host origin (origin-isolation step 1; serves a static bundle only)
+// The isolated reader-host origin (origin-isolation step 1; serves a static bundle only). Compiled
+// only where a WebView actually needs it — see the registration in `run()` for why Windows does not.
+#[cfg(not(target_os = "windows"))]
+pub mod bookhost;
 pub mod settings; // key/value settings persistence
 pub mod sync; // FUTURE seam: backend trait only (placeholder)
 pub mod tts; // read-aloud over the Edge Read-Aloud neural voices
@@ -183,12 +186,25 @@ pub fn run() {
             }
         }))
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_dialog::init())
-        // THE READER-HOST ORIGIN (origin-isolation step 1). A distinct origin serving a static,
-        // allow-listed slice of the frontend bundle: the host document, its script, the bundled
-        // fonts, and the pdf.js assets pdf.js resolves against its own URL. It reads through the
-        // asset resolver, so it has no filesystem path to serve a book with. Nothing embeds it yet.
-        .register_uri_scheme_protocol(bookhost::SCHEME, bookhost::handle);
+        .plugin(tauri_plugin_dialog::init());
+
+    // THE READER-HOST ORIGIN (origin-isolation step 1) — NOT ON WINDOWS, DELIBERATELY.
+    //
+    // A distinct origin serving a static, allow-listed slice of the frontend bundle: the host
+    // document, its script, the bundled fonts, and the pdf.js assets pdf.js resolves against its own
+    // URL. It reads through the asset resolver, so it has no filesystem path to serve a book with.
+    //
+    // WHY IT IS ABSENT ON WINDOWS. It exists to answer ONE measured defect: WebKitGTK does not
+    // deliver input into an iframe sandboxed `allow-same-origin` without `allow-scripts`, while
+    // Blink does. Windows has no such defect, so the host would be an unused origin registered in a
+    // shipping product — new attack surface bought with no benefit. A `cfg` rather than a runtime
+    // check because the difference should be a fact about the binary, not a branch someone can flip:
+    // the Windows executable does not merely leave this unused, it never compiles it, exactly as
+    // `webview_chrome` and `audio_identity` already do for their own platform-specific reasons.
+    //
+    // Nothing embeds this origin yet; registering it serves it, and no reader uses it.
+    #[cfg(not(target_os = "windows"))]
+    let builder = builder.register_uri_scheme_protocol(bookhost::SCHEME, bookhost::handle);
 
     // THE UPDATER — RELEASE BUILDS ONLY, and this cfg is the whole reason it is split out of the
     // chain above. A diagnostic build that carries the public update channel is a diagnostic build

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ pub mod books; // file import, format detection, EPUB/PDF orchestration (placeho
 pub mod metadata; // read embedded metadata + persist user overrides (placeholder)
 pub mod fonts; // register/validate custom fonts (placeholder)
 pub mod photocards; // saved photo cards: PNG store + DB rows (RAWY-52, Photo Mode part 2a)
+pub mod bookhost; // the isolated reader-host origin (origin-isolation step 1; serves a static bundle only)
 pub mod settings; // key/value settings persistence
 pub mod sync; // FUTURE seam: backend trait only (placeholder)
 pub mod tts; // read-aloud over the Edge Read-Aloud neural voices
@@ -182,7 +183,12 @@ pub fn run() {
             }
         }))
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_dialog::init());
+        .plugin(tauri_plugin_dialog::init())
+        // THE READER-HOST ORIGIN (origin-isolation step 1). A distinct origin serving a static,
+        // allow-listed slice of the frontend bundle: the host document, its script, the bundled
+        // fonts, and the pdf.js assets pdf.js resolves against its own URL. It reads through the
+        // asset resolver, so it has no filesystem path to serve a book with. Nothing embeds it yet.
+        .register_uri_scheme_protocol(bookhost::SCHEME, bookhost::handle);
 
     // THE UPDATER — RELEASE BUILDS ONLY, and this cfg is the whole reason it is split out of the
     // chain above. A diagnostic build that carries the public update channel is a diagnostic build


### PR DESCRIPTION
Step 1 of origin isolation. Adds an isolated origin that serves a static, allow-listed slice of the frontend bundle, compiled **only on platforms whose WebView needs it**. Nothing embeds it yet — this registers and serves the origin, and no reader uses it.

## Why it exists

One measured defect: **WebKitGTK does not deliver input into an iframe sandboxed `allow-same-origin` without `allow-scripts`; Blink does.** Upstream foliate-js documents the same thing as WebKit bug 218086. Sard removed `allow-scripts` for D30, which is correct on Blink and breaks input on WebKit.

The host is the minimal enclosure that lets the book iframe carry `allow-scripts` without that being a privilege escalation: its parent holds nothing worth stealing.

## Windows is untouched

`bookhost` and its registration are behind `cfg(not(target_os = "windows"))`, matching `webview_chrome` and `audio_identity`. Measured on the built Windows binary: `sardhost`, `bookhost`, `reader-host` each occur **zero** times.

Zero diff under `src/`, `public/foliate-js/`, `tauri.conf.json`, `capabilities/`.

## Measured on real WebKitGTK

Real Tauri app, real handler, real assets — **11 PASS · 0 FAIL · 0 UNKNOWN**:

| | |
|---|---|
| host origin | `sardhost://localhost` vs app `tauri://localhost` |
| fonts | served (431,116 bytes) and usable as `@font-face` |
| pdf.js | CMap 25,439 bytes + worker served |
| `parent.__TAURI_INTERNALS__` / `.document` / `.location.href`, and `top.*` | all `SecurityError` |
| app reading the host | `contentDocument: null` |
| `/library/book.epub`, `/sard.db`, traversal | 404 |
| CSP | `connect-src` violation raised on a cross-origin fetch |
| MessagePort on host global | none |

## The CSP, and a defect this PR fixes

The first draft named only `script-src`, `style-src` and `connect-src`. Under `default-src 'none'` an omitted directive resolves to `'none'`, so `img-src`, `font-src`, `media-src` and `frame-src` were all closed: that policy could not have shown an image, loaded a custom face, or **created the section iframe at all**.

Content directives now mirror `tauri.conf.json` exactly — the book document inherits that policy today, so matching it is what keeps rendering identical; narrower changes behaviour, wider hands a book reach it does not currently have. Privilege directives stay stricter.

`font-src` carries `asset:` deliberately: user fonts reach the content document as `@font-face { src: url(convertFileSrc(...)) }`.

## Tests

The old assertions checked four directives were *present*, which is why they passed against a policy defined by what was *absent*. They now parse the policy and compare against `tauri.conf.json` in both directions, and a fixture replays the defective draft so the guard is proven to reject it.

8 tests, run on the Linux job — the platform that compiles the module.

## Known residual

6 KB of host assets are still bundled on Windows. Unreachable three ways: no scheme registered, no `sardhost:` in the app CSP's `frame-src`, no frontend reference. Not worth a build-time exclusion rule.

## Scope

`connect-src`/CORS: the run's negative control to a CORS-permissive origin was itself blocked by the *app's* CSP, so criterion 8 rests on the observed `connect-src` violation, not on a controlled comparison. WKWebView and WebView2 remain UNKNOWN and untested.