### PR TITLE
Run the reading engine inside the reader host on WebKit

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node scripts/build-reader-host.mjs",
     "preview": "vite preview",
     "tauri": "tauri",
     "build:test": "node scripts/build-test.mjs",

--- a/public/foliate-js/VENDOR.txt
+++ b/public/foliate-js/VENDOR.txt
@@ -40,6 +40,20 @@ Chromium >= 140 and the EPUB set to Chromium >= 117.)
 
   1. paginator.js:252  — iframe sandbox hardened to `allow-same-origin` only (no allow-scripts).
                          RAWY-64. Book content must never execute script.
+ 1b. paginator.js:252  — and fixed-layout.js:88. That sandbox value is now READ from
+     fixed-layout.js:88   `globalThis.__sardSectionSandbox`, falling back to the exact literal above.
+                         The parent decides, because only the parent knows its engine. Unset — every
+                         Windows build — is behaviour-identical to patch 1.
+                         WHY: MEASURED on WebKitGTK, an iframe sandboxed `allow-same-origin` without
+                         `allow-scripts` never delivers the pointer events the parent listens for, so
+                         patch 1 alone produces a book nobody can touch on that engine. Upstream
+                         documents the same thing (README, WebKit bug 218086) and ships
+                         `allow-scripts` because of it. D30 is preserved by ENCLOSURE rather than by
+                         the attribute: the only place Sard sets this to include `allow-scripts` is
+                         inside the isolated reader host, whose origin holds no Tauri API, no app
+                         document and no secret.
+                         Same global-hook shape as patch 5; reverted by deleting the `??` and its
+                         left operand.
   2. paginator.js      — the `--sard-columns` / `--sard-measure` single-column patch (RAWY-21/23/25).
   3. paginator.js      — the RAWY-75 wheel/scroll-intent patch.
   4. pdf.js            — page canvas copied to an <img> via toDataURL; adoptNode renders blank in

--- a/public/foliate-js/fixed-layout.js
+++ b/public/foliate-js/fixed-layout.js
@@ -85,7 +85,9 @@ export class FixedLayout extends HTMLElement {
         // (a WebKit-only event workaround Sard's Chromium/WebView2 runtime doesn't need) to close
         // the local-code-execution path; `allow-same-origin` alone preserves parent-side
         // `iframe.contentDocument` access for everything Sard's own code needs.
-        iframe.setAttribute('sandbox', 'allow-same-origin')
+        // SARD LOCAL PATCH 1b — read, not hardcoded; see the same line in paginator.js for why.
+        // Unset (every Windows build) yields the identical literal this line carried before.
+        iframe.setAttribute('sandbox', globalThis.__sardSectionSandbox ?? 'allow-same-origin')
         iframe.setAttribute('scrolling', 'no')
         iframe.setAttribute('part', 'filter')
         this.#root.append(element)

--- a/public/foliate-js/paginator.js
+++ b/public/foliate-js/paginator.js
@@ -249,7 +249,17 @@ class View {
         // and the Tauri IPC bridge) while keeping 100% of Sard's own reading/theming/highlight
         // functionality, which all depends on `allow-same-origin` for `iframe.contentDocument`
         // access. Re-apply on any re-vendor, alongside the RAWY-21 --sard-measure patch above.
-        this.#iframe.setAttribute('sandbox', 'allow-same-origin')
+        //
+        // SARD LOCAL PATCH 1b — the value is READ, not hardcoded. The paragraph above is exactly
+        // right about Chromium and exactly wrong about WebKit: MEASURED on WebKitGTK, a script-
+        // disabled iframe never receives the pointer events the parent listens for, so on that
+        // engine the reasoning above produces a book nobody can touch. The parent decides, because
+        // only the parent knows which engine it is on and whether it is running inside the isolated
+        // reader host (where `allow-scripts` costs nothing, since the host holds nothing to steal).
+        // Unset — every Windows build — yields the same literal string as before, so this line is
+        // behaviour-identical there. Same global-hook shape as PATCH 5 in epub.js, and reverted the
+        // same way: delete the `??` and its left operand.
+        this.#iframe.setAttribute('sandbox', globalThis.__sardSectionSandbox ?? 'allow-same-origin')
         this.#iframe.setAttribute('scrolling', 'no')
     }
     get element() {

--- a/public/reader-host/host.js
+++ b/public/reader-host/host.js
@@ -182,10 +182,10 @@
   // — a scan finds nothing and reports zero instrumented documents, which reads exactly like "input
   // never arrived" while actually meaning "nobody was listening".
   //
-  // The engine's own API is the way in, and it is the same route the Windows byte-identity harness
-  // uses to fingerprint a rendered page: `foliate-view` → `renderer.getContents()` → `.doc`. From the
-  // document, `defaultView.frameElement` reaches back out to the iframe element, which is how the
-  // sandbox attribute that patch 1b produced can be read at all.
+  // The engine's own API is the way in: `foliate-view` → `renderer.getContents()` → `.doc`, which is
+  // how anything outside the shadow root reaches a rendered section. From the document,
+  // `defaultView.frameElement` reaches back out to the iframe element, which is how the sandbox
+  // attribute that patch 1b produced can be read at all.
   //
   // Re-scanned rather than instrumented once: every section gets its own iframe and the engine
   // replaces them as the reader moves. An earlier probe attached to the first document only and then

--- a/public/reader-host/host.js
+++ b/public/reader-host/host.js
@@ -34,8 +34,28 @@
     write();
   });
 
+  // The report element is created here and hung off documentElement, not body. The engine owns the
+  // body — `FoliateController.open` calls `container.replaceChildren` and the host hands it a
+  // container it just put there — so a node parked in the body would vanish the moment a book
+  // opened, taking the evidence with it. Kept 1px and pointer-events:none because an earlier probe
+  // used a large off-screen element and it silently swallowed the very clicks being measured.
+  function report() {
+    var el = document.getElementById("report");
+    if (!el || !el.isConnected) {
+      el = document.createElement("pre");
+      el.id = "report";
+      el.setAttribute(
+        "style",
+        "position:fixed;left:0;top:0;width:1px;height:1px;overflow:hidden;" +
+          "pointer-events:none;opacity:0;white-space:pre;margin:0;z-index:-1",
+      );
+      document.documentElement.appendChild(el);
+    }
+    return el;
+  }
+
   function write() {
-    document.getElementById("report").textContent = JSON.stringify(R, null, 1);
+    report().textContent = JSON.stringify(R, null, 1);
   }
 
   function attempt(name, fn) {
@@ -111,4 +131,45 @@
     R.done = true;
     write();
   });
+
+  // -------------------------------------------------------------------------------------------
+  // THE MEASUREMENT THIS WHOLE ARCHITECTURE EXISTS FOR.
+  // -------------------------------------------------------------------------------------------
+  // The defect: on WebKitGTK an iframe sandboxed `allow-same-origin` WITHOUT `allow-scripts` never
+  // delivers pointer events to listeners the parent attached across the frame boundary. That is the
+  // exact shape of every listener the engine uses, so the book renders and nothing responds.
+  //
+  // This listens the same way the engine does — `iframe.contentDocument.addEventListener` from the
+  // parent document — and counts what arrives. It proves nothing on its own: a count only means
+  // something when something real was clicked, so the harness drives a genuine X11 click with
+  // xdotool and reads these counters afterwards. A synthetic dispatchEvent would prove nothing at
+  // all, because the bug is in DELIVERY, not in dispatch.
+  R.input = { sandbox: null, docsInstrumented: 0, pointerdown: 0, mousedown: 0, click: 0, selectionchange: 0 };
+
+  var seen = new WeakSet();
+  function instrument(doc) {
+    if (!doc || seen.has(doc)) return;
+    seen.add(doc);
+    R.input.docsInstrumented++;
+    ["pointerdown", "mousedown", "click"].forEach(function (type) {
+      doc.addEventListener(type, function () { R.input[type]++; write(); }, true);
+    });
+    doc.addEventListener("selectionchange", function () { R.input.selectionchange++; write(); }, true);
+    write();
+  }
+
+  // Every section gets its own iframe and the engine replaces them as the reader moves, so this
+  // re-scans rather than instrumenting once. An earlier probe attached to the first document only
+  // and then measured a different one.
+  setInterval(function () {
+    var frames = document.querySelectorAll("iframe");
+    for (var i = 0; i < frames.length; i++) {
+      var f = frames[i];
+      if (R.input.sandbox === null && f.getAttribute("sandbox") !== null) {
+        R.input.sandbox = f.getAttribute("sandbox"); // what patch 1b actually produced here
+        write();
+      }
+      try { instrument(f.contentDocument); } catch (e) { /* not readable yet */ }
+    }
+  }, 250);
 })();

--- a/public/reader-host/host.js
+++ b/public/reader-host/host.js
@@ -1,12 +1,16 @@
-// The reader host, step 1.
+// The reader host's boundary self-check.
 //
-// The origin exists and carries its policy; nothing reads a book here yet. The engine, the byte
-// transfer, the section sandbox change and the message channel are later steps, each with its own
-// evidence gate, and none of them is present.
+// It measures, from INSIDE this origin, what this origin can actually reach — the one thing no
+// outside observer can establish, because every interesting answer here is a SecurityError that only
+// the code holding the reference can raise.
 //
-// `?selfcheck=1` runs the acceptance checks for this step and writes them into #report. Without it
-// the document is inert, so the checks are a deliberate act rather than something that runs behind
-// a reader every time a book opens.
+// It exists as shipped code, rather than as something a throwaway branch bolts on, because these
+// properties have to stay re-measurable against the REAL host after every change. A boundary proven
+// once against a special build is a boundary nobody can re-check.
+//
+// Inert without `?selfcheck=1`: a normal reader open runs none of it. It is absent from Windows
+// entirely — `scripts/build-reader-host.mjs` deletes this whole directory for that target, because
+// no origin is registered there to serve it.
 (function () {
   "use strict";
 
@@ -146,6 +150,19 @@
   // all, because the bug is in DELIVERY, not in dispatch.
   R.input = { sandbox: null, docsInstrumented: 0, pointerdown: 0, mousedown: 0, click: 0, selectionchange: 0 };
 
+  // THE POSITIVE CONTROL, and the run that lacked it is why it is here.
+  //
+  // A count of zero in the section has two completely different meanings: the engine difference this
+  // architecture exists to fix, or a click that never landed on the window at all. Only a second
+  // counter can separate them. This one is on the HOST's own document — the same window, the same
+  // click, one frame boundary nearer. If this is zero too, the harness missed and the section result
+  // says nothing; if this is non-zero and the section is zero, the gap is real and it is between
+  // these two documents.
+  R.hostInput = { pointerdown: 0, mousedown: 0, click: 0 };
+  ["pointerdown", "mousedown", "click"].forEach(function (type) {
+    document.addEventListener(type, function () { R.hostInput[type]++; write(); }, true);
+  });
+
   var seen = new WeakSet();
   function instrument(doc) {
     if (!doc || seen.has(doc)) return;
@@ -158,18 +175,36 @@
     write();
   }
 
-  // Every section gets its own iframe and the engine replaces them as the reader moves, so this
-  // re-scans rather than instrumenting once. An earlier probe attached to the first document only
-  // and then measured a different one.
+  // FINDING THE SECTION DOCUMENT.
+  //
+  // Not with `document.querySelectorAll("iframe")`. The paginator builds its iframe inside a CLOSED
+  // shadow root (`attachShadow({mode:'closed'})`), so from this document that iframe does not exist
+  // — a scan finds nothing and reports zero instrumented documents, which reads exactly like "input
+  // never arrived" while actually meaning "nobody was listening".
+  //
+  // The engine's own API is the way in, and it is the same route the Windows byte-identity harness
+  // uses to fingerprint a rendered page: `foliate-view` → `renderer.getContents()` → `.doc`. From the
+  // document, `defaultView.frameElement` reaches back out to the iframe element, which is how the
+  // sandbox attribute that patch 1b produced can be read at all.
+  //
+  // Re-scanned rather than instrumented once: every section gets its own iframe and the engine
+  // replaces them as the reader moves. An earlier probe attached to the first document only and then
+  // measured a different one.
   setInterval(function () {
-    var frames = document.querySelectorAll("iframe");
-    for (var i = 0; i < frames.length; i++) {
-      var f = frames[i];
-      if (R.input.sandbox === null && f.getAttribute("sandbox") !== null) {
-        R.input.sandbox = f.getAttribute("sandbox"); // what patch 1b actually produced here
-        write();
+    var view = document.querySelector("foliate-view");
+    if (!view || !view.renderer || typeof view.renderer.getContents !== "function") return;
+    var contents;
+    try { contents = view.renderer.getContents() || []; } catch (e) { return; }
+    for (var i = 0; i < contents.length; i++) {
+      var doc = contents[i] && contents[i].doc;
+      if (!doc) continue;
+      if (R.input.sandbox === null) {
+        try {
+          var fe = doc.defaultView && doc.defaultView.frameElement;
+          if (fe) { R.input.sandbox = fe.getAttribute("sandbox"); write(); }
+        } catch (e) { /* frameElement across the boundary */ }
       }
-      try { instrument(f.contentDocument); } catch (e) { /* not readable yet */ }
+      instrument(doc);
     }
   }, 250);
 })();

--- a/public/reader-host/index.html
+++ b/public/reader-host/index.html
@@ -3,22 +3,27 @@
 <head>
 <meta charset="utf-8">
 <title>Sard reader host</title>
-<!-- The reader-host origin. Step 1 establishes the origin and its policy; the reading engine moves
-     in later, and this body is what it replaces.
+<!-- The reader-host origin: the reading engine, running where it can reach nothing that matters.
 
      There is no inline script anywhere in this document on purpose: the policy this origin ships
      under is `script-src 'self'`, so an inline block would be refused. If one ever appears here and
      the page still works, the policy has stopped being applied and that is a defect, not a
-     convenience. -->
+     convenience.
+
+     `/bundle.js` is emitted by scripts/build-reader-host.mjs and is absent from a Windows build,
+     where no reader host is registered and this document is never served. -->
 <style>
   html, body { margin: 0; height: 100%; background: #f7f2e8; }
-  #report { position: absolute; left: -9999px; top: -9999px; width: 1px; height: 1px;
-            overflow: hidden; pointer-events: none; white-space: pre; }
+  /* The engine measures its own container, so the host must give it a real one to measure. */
+  body > .page-host { height: 100%; }
 </style>
 </head>
 <body>
-  <div id="stage"></div>
-  <pre id="report"></pre>
+  <script type="module" src="/bundle.js"></script>
+  <!-- The boundary self-check. It measures, from INSIDE this origin, what this origin can reach —
+       which is the one thing no external observer can establish. Inert without `?selfcheck=1`, so a
+       normal open runs none of it. It stays because the security criteria have to be re-measurable
+       against the real host after every change, not only against a throwaway build of it. -->
   <script src="/host.js"></script>
 </body>
 </html>

--- a/scripts/build-reader-host.mjs
+++ b/scripts/build-reader-host.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Build the reader-host bundle — for the platforms that have a reader host, and no others.
+//
+// The host exists to answer ONE measured defect: WebKitGTK does not deliver input into an iframe
+// sandboxed `allow-same-origin` without `allow-scripts`, and Blink does. Windows has no such defect
+// and never registers the origin (see the cfg in src-tauri/src/lib.rs), so shipping the bundle there
+// would put the whole reader engine into the Windows artifact a second time, unreachable.
+//
+// WHY THE DEFAULT IS TO BUILD IT. `TAURI_ENV_PLATFORM` is set by the Tauri CLI for beforeBuildCommand
+// and by nothing else, so a bare `npm run build` — CI's typecheck, the production-build gate, a
+// developer checking their work — has no target and gets the bundle. That is deliberate: the default
+// should be the one that COMPILES the code, so a break in the host entry is caught by any ordinary
+// build rather than only by whoever next builds for Linux. Only an explicit Windows target skips it.
+import { execFileSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..");
+const OUT = join(ROOT, "dist", "reader-host");
+const platform = process.env.TAURI_ENV_PLATFORM ?? "";
+
+if (platform === "windows") {
+  // REMOVE THE WHOLE DIRECTORY, not just the bundle this script would have written.
+  //
+  // Two reasons it is a deletion rather than a skip. First, `dist/` is not emptied between builds, so
+  // a bundle left by an earlier non-Windows build would otherwise be embedded in the Windows binary —
+  // the exact outcome this script exists to prevent, and one that would look like it had worked.
+  // Second, the host's document and its self-check arrive from `public/`, which Vite copies
+  // wholesale; skipping only the bundle would still ship the host's HTML in an artifact that
+  // registers no origin to serve it. Nothing here is reachable on Windows, so nothing here ships.
+  if (existsSync(OUT)) {
+    rmSync(OUT, { recursive: true, force: true });
+    console.log("[reader-host] removed dist/reader-host — no origin serves it on this target");
+  }
+  console.log("[reader-host] target is windows — no reader host is registered there, nothing built");
+  process.exit(0);
+}
+
+console.log(`[reader-host] building (target: ${platform || "unspecified"})`);
+
+// Vite's own JS entry, run by the Node already running this — not `npx`. Node refuses to spawn a
+// `.cmd` without a shell (the CVE-2024-27980 fix) and throws EINVAL, so the npx form fails on
+// Windows exactly where this script is most often run; going through a shell to work around that
+// would mean quoting a path that can contain spaces. This has neither problem.
+const VITE = join(ROOT, "node_modules", "vite", "bin", "vite.js");
+if (!existsSync(VITE)) {
+  console.error(`[reader-host] vite not found at ${VITE} — run \`npm ci\` first`);
+  process.exit(1);
+}
+execFileSync(process.execPath, [VITE, "build"], {
+  cwd: ROOT,
+  stdio: "inherit",
+  env: { ...process.env, SARD_BUILD_TARGET: "reader-host" },
+});

--- a/src-tauri/src/bookhost.rs
+++ b/src-tauri/src/bookhost.rs
@@ -301,7 +301,13 @@ mod tests {
             "/fonts/sub/dir/x.ttf",
             "/fonts/book.epub",
             "/pdfjs/../../../epub.js",
-            "/foliate-js/view.js",
+            // `/foliate-js/view.js` USED TO BE ON THIS LIST and is deliberately no longer refused.
+            // It was correct while the host served a static bundle and ran no engine; the host now
+            // runs the engine, and `ensureFoliateDefined` injects exactly that script against this
+            // origin, so refusing it means the reader cannot start here at all. The assertion moved
+            // rather than vanished: `serves_the_engine_the_host_runs` pins what the subtree serves,
+            // and `the_engine_subtree_is_not_a_way_out_of_the_bundle` pins what it still refuses.
+            // Every other entry below is unchanged.
             "/library/book.epub",
             "/sard.db",
             "//evil",

--- a/src-tauri/src/bookhost.rs
+++ b/src-tauri/src/bookhost.rs
@@ -68,8 +68,13 @@ pub const SCHEME: &str = "sardhost";
 /// - `frame-src 'self' blob:` — the paginator CREATES the section iframe from this document. Omit
 ///   this and the reader has no iframe to render into at all.
 ///
-/// `connect-src 'self'` is required rather than `'none'`: pdf.js fetches its own stylesheets
+/// `connect-src 'self' blob:` is required rather than `'none'`: pdf.js fetches its own stylesheets
 /// (`pdf.js:10,13` call `fetchText(pdfjsPath(...))`), so a blanket refusal would break the PDF path.
+/// `blob:` carries the BOOK. Its bytes are transferred in over the command channel and turned into a
+/// blob URL here, deliberately instead of serving the file from this origin — serving it would give
+/// this origin a filesystem route, which is the one thing the allow-list exists to deny and which
+/// `serves_only_the_allow_listed_bundle` asserts it does not have. A blob URL can only be created by
+/// script already running in this origin, so it grants no reach that was not already granted.
 ///
 /// MEASURED, WebKitGTK only: with this policy a fetch to the application origin and to a
 /// CORS-permissive third origin both fail and both raise a `connect-src` violation, while a
@@ -86,7 +91,7 @@ const CSP: &str = "default-src 'none'; \
                    font-src 'self' asset: http://asset.localhost https://asset.localhost blob: data:; \
                    media-src blob:; \
                    frame-src 'self' blob:; \
-                   connect-src 'self'";
+                   connect-src 'self' blob:";
 
 /// Map a request path onto a bundle path, or refuse.
 ///
@@ -102,7 +107,24 @@ fn resolve(path: &str) -> Option<String> {
     match p {
         "" | "/" | "/index.html" => Some("reader-host/index.html".into()),
         "/host.js" => Some("reader-host/host.js".into()),
+        // The reading engine, built for this origin. One fixed name, because an allow-list cannot
+        // name a hashed one — and widening this to `/assets/*.js` to accommodate hashing would serve
+        // the APPLICATION's bundle from the book's origin too. `inlineDynamicImports` in the host
+        // build is what makes one name sufficient: there are no sibling chunks to fetch.
+        "/bundle.js" => Some("reader-host/bundle.js".into()),
         _ => {
+            if let Some(rest) = p.strip_prefix("/foliate-js/") {
+                // The engine's own modules. `FoliateController.ensureFoliateDefined` injects
+                // `<script src="/foliate-js/view.js">` against the DOCUMENT's origin, and view.js
+                // then imports its siblings relatively — so once the engine runs here, the whole
+                // module graph has to resolve here. Extensions are still allow-listed: this serves
+                // JavaScript and its assets, never an arbitrary bundle path.
+                return safe_path(
+                    rest,
+                    &["js", "mjs", "css", "json", "bcmap", "pfb", "ttf", "otf", "woff", "woff2", "wasm"],
+                )
+                .map(|r| format!("foliate-js/{r}"));
+            }
             if let Some(name) = p.strip_prefix("/fonts/") {
                 // Bundled faces only. `absFontUrl` (injectedCss.ts:179) pins @font-face to
                 // `location.origin`, so once the engine runs here these must resolve here.
@@ -134,24 +156,31 @@ fn safe_segment(name: &str, exts: &[&str]) -> Option<String> {
     exts.contains(&ext.as_str()).then(|| name.to_string())
 }
 
-/// The same rule, but permitting a single directory level (`cmaps/…`, `standard_fonts/…`).
+/// The same rule over a nested path: every directory segment conservative, the last one a file whose
+/// extension is on the list.
+///
+/// Depth is not the security property and never was — the per-segment character set is. A directory
+/// segment may not contain a dot, so `..` cannot BE a segment, and the caller has already refused any
+/// path containing `..` at all. What keeps this tight is that every segment must be alphanumeric with
+/// `_`/`-`, and the leaf must end in an allow-listed extension.
+///
+/// It used to stop at one directory level, which was enough for `pdfjs/cmaps/…`. The engine's own
+/// tree is deeper (`vendor/pdfjs/cmaps/UniJIS-UCS2-H.bcmap`), and capping the depth would have meant
+/// a second near-identical function whose rules could drift from this one.
 fn safe_path(rest: &str, exts: &[&str]) -> Option<String> {
-    let mut parts = rest.split('/');
-    let first = parts.next()?;
-    match parts.next() {
-        None => safe_segment(first, exts),
-        Some(name) if parts.next().is_none() => {
-            let dir_ok = !first.is_empty()
-                && first
-                    .chars()
-                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-'));
-            if !dir_ok {
-                return None;
-            }
-            safe_segment(name, exts).map(|n| format!("{first}/{n}"))
+    let parts: Vec<&str> = rest.split('/').collect();
+    let (leaf, dirs) = parts.split_last()?;
+    for dir in dirs {
+        let ok = !dir.is_empty()
+            && dir
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-'));
+        if !ok {
+            return None;
         }
-        _ => None, // deeper than the bundle needs
     }
+    let leaf = safe_segment(leaf, exts)?;
+    Some(if dirs.is_empty() { leaf } else { format!("{}/{leaf}", dirs.join("/")) })
 }
 
 fn mime_for(path: &str) -> &'static str {
@@ -223,6 +252,47 @@ mod tests {
         );
     }
 
+    /// The engine's own module graph. `ensureFoliateDefined` injects `/foliate-js/view.js` against
+    /// the DOCUMENT's origin and view.js imports its siblings relatively, so every one of these has
+    /// to resolve here or the engine cannot start in the host at all.
+    #[test]
+    fn serves_the_engine_the_host_runs() {
+        for (req, want) in [
+            ("/bundle.js", "reader-host/bundle.js"),
+            ("/foliate-js/view.js", "foliate-js/view.js"),
+            ("/foliate-js/epub.js", "foliate-js/epub.js"),
+            ("/foliate-js/paginator.js", "foliate-js/paginator.js"),
+            ("/foliate-js/fixed-layout.js", "foliate-js/fixed-layout.js"),
+            ("/foliate-js/pdf.js", "foliate-js/pdf.js"),
+            (
+                "/foliate-js/vendor/pdfjs/cmaps/UniJIS-UCS2-H.bcmap",
+                "foliate-js/vendor/pdfjs/cmaps/UniJIS-UCS2-H.bcmap",
+            ),
+            ("/foliate-js/vendor/pdfjs/pdf.mjs", "foliate-js/vendor/pdfjs/pdf.mjs"),
+        ] {
+            assert_eq!(resolve(req).as_deref(), Some(want), "{req}");
+        }
+    }
+
+    /// Serving a whole subtree is where an allow-list is easiest to get wrong, so the refusals are
+    /// named as explicitly as the permissions.
+    #[test]
+    fn the_engine_subtree_is_not_a_way_out_of_the_bundle() {
+        for p in [
+            "/foliate-js/../sard.db",
+            "/foliate-js/vendor/../../secret.js",
+            "/foliate-js/view.js.map",       // source maps are not on the extension list
+            "/foliate-js/VENDOR.txt",        // nor is anything that is not code or an asset
+            "/foliate-js/",                  // no leaf
+            "/foliate-js/sub dir/view.js",   // space is not in the segment character set
+            "/foliate-js/.hidden/view.js",   // a dot cannot appear in a directory segment
+            "/bundle.js.map",
+            "/reader-host/bundle.js",        // the mapped name is not also a request path
+        ] {
+            assert!(resolve(p).is_none(), "should refuse {p}");
+        }
+    }
+
     #[test]
     fn refuses_everything_else() {
         for p in [
@@ -288,7 +358,21 @@ mod tests {
         let d = directives(CSP);
         assert_eq!(d.get("default-src").map(String::as_str), Some("'none'"));
         assert_eq!(d.get("script-src").map(String::as_str), Some("'self'"));
-        assert_eq!(d.get("connect-src").map(String::as_str), Some("'self'"));
+        assert_eq!(d.get("connect-src").map(String::as_str), Some("'self' blob:"));
+    }
+
+    /// The book arrives as bytes and becomes a blob URL in this origin, so `connect-src` has to admit
+    /// `blob:` — and must not admit anything that would let it be fetched from somewhere else instead.
+    #[test]
+    fn connect_src_admits_the_book_blob_and_nothing_remote() {
+        let connect = directives(CSP).remove("connect-src").expect("declared");
+        assert!(connect.split_whitespace().any(|t| t == "blob:"), "the book needs blob:");
+        for forbidden in ["*", "http:", "https:", "ws:", "wss:", "data:", "asset:"] {
+            assert!(
+                !connect.split_whitespace().any(|t| t == forbidden),
+                "connect-src must not admit {forbidden}"
+            );
+        }
     }
 
     /// `default-src 'none'` means an OMITTED directive resolves to `'none'`. Every resource kind the

--- a/src/reader-host/main.ts
+++ b/src/reader-host/main.ts
@@ -1,0 +1,132 @@
+// The reader host — the reading engine, running in an origin that holds nothing worth stealing.
+//
+// WHY THIS EXISTS. MEASURED on WebKitGTK: an iframe sandboxed `allow-same-origin` without
+// `allow-scripts` never delivers the pointer events the engine's parent-side listeners are waiting
+// for. Blink does deliver them, which is why Windows has never needed any of this. Upstream
+// foliate-js documents the same engine difference (WebKit bug 218086) and ships `allow-scripts`
+// because of it; Sard removed it for D30.
+//
+// The resolution is enclosure, not surrender. Book content gets `allow-scripts` again — but the
+// document it can reach is THIS one, served from `sardhost://`, which has no Tauri API, no
+// application document, no database handle and no secret. D30's intent ("a book must not reach
+// anything that matters") holds; only the mechanism moved from the sandbox attribute to the origin.
+//
+// MEASURED from inside this origin, real Tauri app, real WebKitGTK: `parent.__TAURI_INTERNALS__`,
+// `parent.document`, `parent.location.href` and every `top.*` equivalent raise SecurityError, the
+// application cannot read back into here, and a cross-origin fetch raises a `connect-src` violation.
+//
+// This file is built by `scripts/build-reader-host.mjs` into ONE self-contained bundle and is not
+// emitted at all for a Windows target.
+import { FoliateController } from "../reader-engine/FoliateController";
+
+// ---------------------------------------------------------------------------------------------
+// The section sandbox. Set BEFORE the engine can create a single iframe.
+// ---------------------------------------------------------------------------------------------
+// Read by the two vendored call sites (paginator.js, fixed-layout.js — VENDOR patch 1b). Setting it
+// here rather than in the engine keeps the decision with the only code that knows where it is: this
+// bundle exists solely on the hosted path, so its presence IS the condition. Nothing sets it in the
+// application origin, where the fallback keeps today's exact value.
+(globalThis as { __sardSectionSandbox?: string }).__sardSectionSandbox =
+  "allow-same-origin allow-scripts";
+
+// ---------------------------------------------------------------------------------------------
+// The command channel.
+// ---------------------------------------------------------------------------------------------
+// A MessagePort held in a closure and never written to any global. MEASURED: a port left reachable
+// on the global was hijacked in a proof-of-concept and its forged messages were accepted on the
+// trusted channel, so reachability is the whole property — `messagePortsOnGlobal: none` is a Step 1
+// exit criterion, and this is what keeps it true.
+//
+// The handshake is authenticated on `e.source`, not `e.origin`. MEASURED: `e.origin` cannot
+// distinguish the application from book content that forged a message, and `e.source` can.
+type Cmd =
+  | { id: number; cmd: "open"; bytes: ArrayBuffer; opts: OpenArgs }
+  | { id: number; cmd: "navKey"; key: string }
+  | { id: number; cmd: "state" };
+
+// Only the fields the host needs to open a book. Deliberately not a re-declaration of the engine's
+// OpenOptions: this is the wire, and a wire that mirrors an internal type drifts with it silently.
+interface OpenArgs {
+  style: unknown;
+  theme?: unknown;
+  flags?: unknown;
+  dir?: string | null;
+  flow?: "scrolled" | "paged";
+  resumeCfi?: string | null;
+  resumeFraction?: number | null;
+}
+
+const controller = new FoliateController();
+let stage: HTMLElement | null = null;
+let bookUrl: string | null = null;
+
+function ensureStage(): HTMLElement {
+  if (stage) return stage;
+  const el = document.createElement("div");
+  el.className = "page-host"; // the selector the engine and the harness both look for
+  document.body.replaceChildren(el);
+  stage = el;
+  return el;
+}
+
+async function run(msg: Cmd): Promise<unknown> {
+  switch (msg.cmd) {
+    case "open": {
+      // The bytes arrive transferred, not copied. MEASURED equivalent to serving the file from the
+      // host origin (1257 ms vs 1278 ms on a 14.1 MB EPUB), and chosen over it because serving a
+      // file would give this origin a filesystem route — the one thing bookhost.rs is built to
+      // refuse, and what its `/library/book.epub -> 404` test asserts.
+      //
+      // A blob URL rather than a File: foliate's `makeBook` sniffs `%PDF-` from the bytes
+      // themselves, so format detection does not depend on a filename and the engine needs no
+      // change to accept this. The three places the engine matches `.pdf` against the source are
+      // diagnostic labels only, compiled out of a release build.
+      if (bookUrl) URL.revokeObjectURL(bookUrl);
+      bookUrl = URL.createObjectURL(new Blob([msg.bytes]));
+      await controller.open(bookUrl, ensureStage(), msg.opts as never);
+      return { opened: true };
+    }
+    // The engine has no next()/prev(); `handleNavKey` IS its navigation entry point, and it is the
+    // one the application already calls (Reader.tsx:1587). Forwarding the key rather than inventing
+    // a next/prev pair keeps the hosted surface the same surface, so nothing here has to decide what
+    // a page turn means — including which direction "forward" is in an RTL book.
+    case "navKey":
+      return { handled: controller.handleNavKey(msg.key) };
+    case "state":
+      return {
+        section: controller.currentSectionIndex(),
+        toc: controller.getToc().length,
+        atChapterStart: controller.atChapterStart(),
+      };
+  }
+}
+
+function attach(port: MessagePort): void {
+  port.onmessage = (e: MessageEvent<Cmd>) => {
+    const msg = e.data;
+    void (async () => {
+      try {
+        port.postMessage({ id: msg.id, ok: true, value: await run(msg) });
+      } catch (err) {
+        port.postMessage({ id: msg.id, ok: false, error: String(err) });
+      }
+    })();
+  };
+  port.start();
+}
+
+addEventListener("message", (e: MessageEvent) => {
+  // `e.source` is the only trustworthy discriminator here — see above. Book content lives in a
+  // descendant frame, so it can never satisfy this.
+  if (e.source !== parent) return;
+  const data = e.data as { __sardHostInit?: boolean } | null;
+  if (!data?.__sardHostInit) return;
+  const port = e.ports[0];
+  if (!port) return;
+  attach(port);
+  port.postMessage({ id: 0, ok: true, value: { ready: true, origin: location.origin } });
+});
+
+// Tell the application the host is live and listening. It cannot be told over the port, because the
+// port is what this announces the readiness to send.
+parent.postMessage({ __sardHostReady: true }, "*");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -86,11 +86,43 @@ const diagOffPlugin = {
 // @ts-expect-error process is a nodejs global
 const BUILD_ID = process.env.SARD_BUILD_ID || "UNSET — built directly, not through the Sard build scripts";
 
+// THE READER-HOST BUNDLE — a SECOND build of this same config, not a second configuration.
+//
+// The host runs the reader engine inside an isolated origin on WebKit (see src-tauri/src/bookhost.rs).
+// That code is the same `src/reader-engine` the application uses, so it needs the same `@diag`
+// aliasing, the same substitution and the same build id — and getting those from a separate config
+// file would mean two places to keep in step. A target switch reuses every plugin above verbatim.
+//
+// `inlineDynamicImports` makes the result ONE self-contained file. Shared chunks would be emitted to
+// `assets/`, which the host origin deliberately does not serve — its allow-list names each path it
+// answers, and widening it to `/assets/*.js` would hand the book origin the application's own bundle.
+// @ts-expect-error process is a nodejs global
+const IS_READER_HOST = process.env.SARD_BUILD_TARGET === "reader-host";
+
+const READER_HOST_BUILD = {
+  outDir: "dist/reader-host",
+  emptyOutDir: false, // the static index.html is already there, copied from public/
+  rollupOptions: {
+    input: resolve(import.meta.dirname, "src/reader-host/main.ts"),
+    output: {
+      format: "es" as const,
+      entryFileNames: "bundle.js", // fixed, because bookhost.rs allow-lists this exact path
+      inlineDynamicImports: true,
+    },
+  },
+};
+
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: IS_DIAG ? [diagAliasPlugin, react()] : [diagAliasPlugin, diagOffPlugin, react()],
 
   define: { __SARD_BUILD_ID__: JSON.stringify(BUILD_ID) },
+
+  // `publicDir: false` matters as much as the build block. Vite copies the public directory into
+  // outDir on EVERY build, so without this the host build copies all of `public/` a second time into
+  // `dist/reader-host/` — fonts, the whole foliate-js tree, everything — producing a duplicate of the
+  // bundle's own assets nested inside it. The application build already placed those files once.
+  ...(IS_READER_HOST ? { build: READER_HOST_BUILD, publicDir: false as const } : {}),
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //


### PR DESCRIPTION
The engine now has somewhere to run on the platforms that need it. **Nothing is wired to the host yet** — the application still constructs `FoliateController` directly, so no reader changes behaviour on any platform in this PR.

## Windows

Two lines change in code that ships on Windows:

```diff
-        this.#iframe.setAttribute('sandbox', 'allow-same-origin')
+        this.#iframe.setAttribute('sandbox', globalThis.__sardSectionSandbox ?? 'allow-same-origin')
```

Nothing in the application origin sets that global, so the fallback yields the identical literal. Same global-hook shape as the existing `__sardSanitiseBookCss` patch; recorded as VENDOR patch 1b.

**Measured, real binary, real corpus, 13 books:**

| | |
|---|---|
| `preseam-scrolled` | **byte-identical** |
| `preseam-paged` | 3 clean / 1 flake in 4 runs — identical rate, book and values to the pre-change measurement |
| `src/reader-engine/` | zero diff |
| `src/features/` | zero diff |
| `tauri.conf.json`, `capabilities/` | zero diff |
| Unit suite | 309 passed / 11 skipped |
| Production tree + content gates | pass |

The paged flake is `txt-converted--daw-alkhalid.epub` (`sampledSection 22 → 0`, `layout.pages 25 → 26`), documented before this change and unchanged by it. No other book or field ever differs.

**Windows ships none of the host.** The build script deletes `dist/reader-host` outright for a Windows target — skipping only the bundle would still ship the host's HTML, since it arrives from `public/` which Vite copies wholesale. Verified: directory absent after a Windows-target build, present after a Linux one.

## The host

One self-contained bundle from the same Vite config as the application, so the engine inside it is the same engine with the same `@diag` aliasing. `inlineDynamicImports` keeps it to one file — shared chunks would land in `assets/`, and serving those from this origin would hand the book the application's own bundle.

**No engine change was needed to open a book from transferred bytes.** The host wraps them in a blob URL in its own origin rather than having Rust serve the file, which would have given this origin the filesystem route the allow-list exists to deny. Format detection survives because foliate sniffs `%PDF-` from the bytes; the three places the engine matches `.pdf` against the source are diagnostic labels, compiled out of release.

`connect-src` gains `blob:` for exactly that, and a test asserts it admits no remote scheme.

## `safe_path` depth

It stopped at one directory level, which suited `pdfjs/cmaps/…` but not the engine's own tree. Depth was never the security property: no directory segment may contain a dot, so `..` cannot be one, every segment is alphanumeric with `_`/`-`, and every leaf needs an allow-listed extension. Refusals are tested as explicitly as permissions.

## Not yet verified

The hosted transport has **not** been exercised at runtime on WebKitGTK in this PR — the host bundle is built and served, and the probe that drives a real book through it is the next gate. macOS untouched.