### PR TITLE
Map how each engine member crosses the reader-host boundary

### DIFF
--- a/src/reader-transport/surface.ts
+++ b/src/reader-transport/surface.ts
@@ -1,0 +1,110 @@
+// How every method of the reading engine crosses — or cannot cross — a process-like boundary.
+//
+// WHY THIS FILE EXISTS AT ALL. On Windows the application calls `FoliateController` directly and
+// none of this applies. On WebKit the engine runs inside the reader host, in a different origin, and
+// every call has to travel over a `MessagePort`. A port carries structured-cloneable values and
+// nothing else, and it is asynchronous in both directions — two facts that decide, per method,
+// whether it can be forwarded mechanically, needs mirrored state, or cannot cross at all.
+//
+// It is a MAP, not an abstraction. Nothing here wraps or re-implements the engine; it records what
+// the engine's own signatures already imply, so the hosted transport can be generated from it rather
+// than hand-written 72 times, and so `readerSurface.test.ts` can fail the build the day the engine
+// grows a method nobody classified.
+
+/** How a member of the engine's surface behaves across the host boundary. */
+export type Crossing =
+  /** Returns a promise already, or returns nothing. Forwarded verbatim; the reply resolves it. */
+  | "async"
+  /** Returns synchronously from state the host can push ahead of the call. Served from the mirror. */
+  | "mirrored"
+  /** Decided in the application from a SHARED pure module plus mirrored state — never re-implemented. */
+  | "decided-locally"
+  /** The application registers a callback; the host pushes an event and the application invokes it. */
+  | "callback"
+  /** The host registers a callback and expects a SYNCHRONOUS answer. A port cannot answer in time. */
+  | "sync-callback"
+  /** Signature carries a live DOM object. It cannot be cloned, so it does not cross. */
+  | "dom-bound";
+
+/**
+ * The classification, one entry per public member of `FoliateController`.
+ *
+ * Only the entries that are NOT plain `async` are listed. Everything absent from this table is
+ * forwarded mechanically, which is why the table stays short and the guard test compares it against
+ * the real class rather than against a second hand-written list.
+ */
+export const CROSSING: Readonly<Record<string, Crossing>> = Object.freeze({
+  // ---- served from mirrored state -------------------------------------------------------------
+  // MEASURED: each of these reads controller state and touches no DOM, so the host can push a
+  // snapshot after every command and the application can answer from it without waiting.
+  currentSectionIndex: "mirrored",
+  atChapterStart: "mirrored",
+  isTtsChapterOnScreen: "mirrored",
+  bookmarkVisible: "mirrored",
+  hasNextSection: "mirrored",
+  getToc: "mirrored",
+  tocHrefSectionMap: "mirrored",
+  targetSectionIndex: "mirrored",
+  getTtsCursor: "mirrored",
+  pdfTextQuality: "mirrored",
+  pdfRenderedScale: "mirrored",
+  pdfHasSpeakableText: "mirrored",
+
+  // ---- decided in the application ---------------------------------------------------------------
+  // `handleNavKey` is called from a keydown listener and its answer drives `preventDefault()`, so it
+  // cannot wait for a round trip. It does not need to: its decision is `navIntent(key)` — a pure
+  // module that already exists on its own, with its own tests, precisely so there is ONE copy — plus
+  // `isFixedLayout`, which is mirrored, plus the arrow callback, which the APPLICATION registered and
+  // therefore already holds. The side effect it triggers is forwarded and not waited on.
+  handleNavKey: "decided-locally",
+  // Reads a live layout property of the host document.
+  openingUnderTopBar: "mirrored",
+
+  // ---- application-registered callbacks; the host pushes the event ------------------------------
+  onSelection: "callback",
+  onShowAnnotation: "callback",
+  onActivity: "callback",
+  onZoomIntent: "callback",
+  onScrollIntent: "callback",
+  onReadingRedraw: "callback",
+  onRelocate: "callback",
+  onReferenceHit: "callback",
+
+  // ---- the host asks the application and needs the answer NOW -----------------------------------
+  // The engine calls these mid-gesture and branches on what comes back, so an asynchronous reply is
+  // not merely slower, it arrives after the decision has been made. Both are resolved the same way
+  // `handleNavKey` is: the application owns the callback, so it consults it itself and forwards only
+  // the consequence. Neither is re-implemented anywhere.
+  onArrow: "sync-callback",
+  onSpace: "sync-callback",
+
+  // ---- carries a live DOM object ----------------------------------------------------------------
+  // `open` takes the container to render into. Hosted, the host supplies its own and the parameter
+  // never travels.
+  open: "dom-bound",
+  // `range` is OPTIONAL on SelectionInfo and its absence is an established path: RAWY-227 documents a
+  // 24-character normalised text match as the fallback, with the chapter top as last resort. Hosted,
+  // the range stays in the host and the documented fallback runs — the same code the application
+  // already executes today whenever a selection arrives without one.
+  ttsUnitIndexForRange: "dom-bound",
+  // Returns ranges. Its only consumer is `window.__sardPdfTts`, a diagnostic hook, and it uses them
+  // solely to COUNT how many units carry one.
+  getChapterUnits: "dom-bound",
+  // Called only from inside the engine; never reached from the application.
+  highlightAtPoint: "dom-bound",
+  referenceAtPoint: "dom-bound",
+  // Returns a string synchronously, built by walking the live section layout. The application calls
+  // it once, inside a `setTimeout`, to store a developer snapshot in settings (Reader.tsx:1127) —
+  // never on a path a reader can feel. Hosted it becomes a round trip like any other read; it is
+  // listed here so that fact is a decision rather than an oversight.
+  diagnose: "dom-bound",
+});
+
+/** Members that must never be forwarded blindly, because a port cannot carry what they carry. */
+export const NEEDS_SPECIAL_HANDLING: ReadonlySet<Crossing> = new Set<Crossing>([
+  "mirrored",
+  "decided-locally",
+  "callback",
+  "sync-callback",
+  "dom-bound",
+]);

--- a/tests/unit/readerSurface.test.ts
+++ b/tests/unit/readerSurface.test.ts
@@ -1,0 +1,91 @@
+// The engine's surface, and whether every part of it can cross the reader-host boundary.
+//
+// WHAT THIS CAN AND CANNOT PROVE. It reads `FoliateController.ts` as a FILE, the same way
+// `ttsUnitStructure.test.ts` does, because the question is a property of the source and needs no
+// browser: does every public member of the engine have a recorded answer for "how does this cross?"
+// It cannot prove any of those answers is correct — the runtime gate on WebKitGTK does that. What it
+// prevents is the failure that has no other detector: someone adds a method to the engine, the
+// hosted transport forwards it blindly because nothing said not to, and the first person to find out
+// is a reader on Linux whose selection silently stopped working.
+//
+// It runs on every platform on purpose. The classification is about the engine, not about the host,
+// and Windows is where the engine is edited most.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { CROSSING } from "../../src/reader-transport/surface";
+
+const SRC = join(import.meta.dirname, "..", "..", "src", "reader-engine", "FoliateController.ts");
+
+/**
+ * Public method names declared on the class.
+ *
+ * Matched at exactly two levels of indentation, which is what a class member has in this file, and
+ * deliberately not with a TypeScript parser: the suite runs on Node with no build step, and a regex
+ * that over-matches would be caught immediately by the assertions below rather than passing quietly.
+ */
+function publicMethods(source: string): string[] {
+  const names = new Set<string>();
+  // The line must END in `{`. Without that the pattern also matched plain CALL statements sitting at
+  // the same indentation inside module-level functions — `walk(raw, level);` and
+  // `collectLeadingBlocks(body, MAX, blocks);` were both reported as unclassified engine members.
+  // A declaration opens a body on the same line here; a call ends in a semicolon.
+  // Ending in `{` is the whole discriminator, and it must NOT also forbid semicolons: four real
+  // members were lost that way, because an inline object type puts one inside the signature —
+  // `getChapterUnits(...): Promise<{ text: string; range: Range | null }[]> {`. A call statement
+  // ends in `;`, so requiring `{` already excludes it.
+  const re = /^ {2}(?:async\s+)?([a-zA-Z][A-Za-z0-9_]*)\s*(?:<[^>]*>)?\(.*\{\s*$/gm;
+  for (const m of source.matchAll(re)) {
+    const name = m[1];
+    // Control-flow keywords indent the same way a member does; they are not members.
+    if (["if", "for", "while", "switch", "catch", "return", "constructor"].includes(name)) continue;
+    names.add(name);
+  }
+  return [...names].sort();
+}
+
+describe("reader engine surface", () => {
+  const source = readFileSync(SRC, "utf8");
+  const methods = publicMethods(source);
+
+  it("finds the engine's methods at all", () => {
+    // A guard on the guard. If the regex stops matching — the file is reformatted, the class is
+    // wrapped — every assertion below would pass vacuously against an empty list.
+    expect(methods.length).toBeGreaterThan(50);
+    for (const anchor of ["open", "handleNavKey", "getToc", "onSelection", "ttsUnitIndexForRange"]) {
+      expect(methods).toContain(anchor);
+    }
+  });
+
+  it("classifies every member that cannot simply be forwarded", () => {
+    // The direction that matters. Anything the engine declares and the map does not mention is
+    // treated as plain async forwarding — fine for most methods, wrong and silent for a method that
+    // returns synchronously, takes a DOM object, or registers a callback.
+    //
+    // A new member is not a failure by itself. It fails only if its SHAPE says it cannot be
+    // forwarded: a non-promise return, a DOM type, or a callback parameter.
+    const unclassified = methods.filter((name) => !(name in CROSSING));
+    const suspicious = unclassified.filter((name) => {
+      const sig = source.match(new RegExp(`^ {2}(?:async\\s+)?${name}\\s*(?:<[^>]*>)?\\([^)]*\\)[^{]*`, "m"))?.[0] ?? "";
+      const returnsPromise = /:\s*Promise</.test(sig);
+      const isAsync = /^\s{2}async\s/.test(sig);
+      const returnsVoid = /:\s*void\s*$/.test(sig.trim());
+      const takesCallback = /\bcb\s*:/.test(sig);
+      const touchesDom = /\b(Range|HTMLElement|Document|Node|Element|Selection)\b/.test(sig);
+      return takesCallback || touchesDom || !(returnsPromise || isAsync || returnsVoid);
+    });
+
+    expect(
+      suspicious,
+      "these engine members cannot be forwarded verbatim over a MessagePort and are not in " +
+        "src/reader-transport/surface.ts — classify each one before the hosted transport ships it",
+    ).toEqual([]);
+  });
+
+  it("does not classify members the engine no longer has", () => {
+    // The opposite drift: a rename leaves an entry describing a method that is gone, and the map
+    // starts documenting history instead of the code.
+    const stale = Object.keys(CROSSING).filter((name) => !methods.includes(name));
+    expect(stale, "these entries name members FoliateController no longer declares").toEqual([]);
+  });
+});


### PR DESCRIPTION
Groundwork for wiring `HostedReaderTransport`. **Forwards nothing yet** — no platform selection, no change at `Reader.tsx:140`, no reader behaviour change anywhere.

## Why this comes first

A `MessagePort` is asynchronous in both directions and carries only structured-cloneable values. Those two facts decide, per engine member, whether it can be forwarded mechanically. Writing 72 forwards before answering that would mean discovering the exceptions at runtime on Linux.

## What the evidence says

| Crossing | Count | Resolution |
|---|---|---|
| plain async | ~52 | forwarded verbatim (absent from the map by design) |
| `mirrored` | 13 | read state, touch no DOM — a snapshot pushed after each command answers them |
| `decided-locally` | 1 | `handleNavKey` |
| `callback` | 8 | host pushes the event, application invokes its own callback |
| **`sync-callback`** | **2** | **`onArrow`, `onSpace`** |
| `dom-bound` | 5 | see below |

**`handleNavKey`** can't wait — its answer drives `preventDefault()`. It doesn't need to: the decision is `navIntent(key)`, already a separate module with its own tests *precisely so there is one copy*, plus a mirrored boolean, plus a callback the application registered.

**The five DOM-bound members do not block the seam:**
- `open` — the container is supplied by the host itself
- `ttsUnitIndexForRange` — `range` is **optional**, and its absence already runs the documented RAWY-227 24-char text-match fallback
- `getChapterUnits` — returns ranges only to `window.__sardPdfTts`, which uses them to *count*
- `highlightAtPoint`, `referenceAtPoint` — never called from the application
- `diagnose` — one call inside a `setTimeout`, storing a dev snapshot

## A finding that corrects an earlier study

`onArrow` and `onSpace` are callbacks the **engine** invokes and whose boolean it branches on mid-gesture. A port cannot answer synchronously, so a reply arrives after the decision is made. My earlier implementation-impact study concluded the seam had exactly one synchronous decision path; there are **three**. They resolve the same way — the application owns the callback and forwards only the consequence — but the seam is wider than that study implied, and the estimate should be corrected rather than quietly absorbed.

## The guard

`tests/unit/readerSurface.test.ts` reads `FoliateController.ts` as a file, following the precedent in `ttsUnitStructure.test.ts`, and fails when a member's **shape** says it cannot be forwarded and nothing classified it. It also fails on stale entries naming members that no longer exist.

It bit twice while being written: it caught `diagnose` unclassified, and when the pattern was tightened too far it caught the four members it had begun missing.

## Verification

- Unit suite **312 passed / 11 skipped** (up from 309 — three new)
- Windows-target build: `dist/reader-host` **absent**
- `src/reader-engine/`, `public/foliate-js/`, `Reader.tsx`: **zero diff**