### PR TITLE
Application half of the hosted reader transport

### DIFF
--- a/src/reader-engine/FoliateController.ts
+++ b/src/reader-engine/FoliateController.ts
@@ -26,6 +26,9 @@ import {
   type RevealLabels,
 } from "./injectedCss";
 import { navIntent } from "./navIntent";
+// RAWY-229: pure, and therefore shared. The hosted transport applies the same rule in the
+// application, because `bookmarkVisible` is read from a React render body that cannot await.
+import { sameSection } from "./cfiSection";
 import { normalizePdfText, stripPdfArtifacts, hasSpeakableText, scorePdfDocument, PDF_TTS_ENABLED, type PdfTextScore } from "../lib/pdfText"; // RAWY-292
 import { stageEnter as diagStageEnter, stageOk as diagStageOk, stageFail as diagStageFail, probePdfChain as diagProbeChain, watchFirstPage as diagWatchFirstPage } from "@pdfDiag"; // DIAGNOSTIC BUILD ONLY
 import { diagAttachDocument, diagNote, diagPublishUnits } from "@diag"; // DIAGNOSTIC BUILD ONLY
@@ -2754,20 +2757,10 @@ export class FoliateController {
    *  made the marker vanish mid-chapter and let the button add a 2nd bookmark) and NOT the whole-book
    *  fraction window (that lit the marker in every chapter of a long book — the original FEEDBACK 1.6 bug). */
   bookmarkVisible(bookmarkCfi: string | null | undefined, currentCfi: string | null | undefined): boolean {
-    const a = this.cfiSection(bookmarkCfi);
-    const b = this.cfiSection(currentCfi);
-    return a != null && a === b;
-  }
-
-  /** RAWY-229: the SPINE SECTION of a foliate CFI — the step before `!` (or the whole inner CFI at a
-   *  section boundary, which has no `!`), with any `[assertion]` stripped. Two CFIs in the same chapter
-   *  share it exactly, so string equality is "same chapter". Pure; no engine call. */
-  private cfiSection(cfi: string | null | undefined): string | null {
-    if (!cfi) return null;
-    const m = /^epubcfi\((.*)\)$/.exec(cfi.trim());
-    const inner = m ? m[1] : cfi.trim();
-    const spine = inner.split("!")[0].replace(/\[[^\]]*\]/g, "").trim();
-    return spine || null;
+    // Delegates to `cfiSection.ts`. The rule is pure and the hosted transport has to apply it in the
+    // application — `Reader.tsx:300` calls this inside a React render body, which cannot await a
+    // round trip to the reader host. One copy, so the two callers can never disagree.
+    return sameSection(bookmarkCfi, currentCfi);
   }
 
   /** RAWY-186: is the chapter the TTS SESSION is reading the one currently ON SCREEN? `ttsUnitsIndex`

--- a/src/reader-engine/cfiSection.ts
+++ b/src/reader-engine/cfiSection.ts
@@ -1,0 +1,46 @@
+// RAWY-229: the SPINE SECTION of a foliate CFI, and the "same chapter?" test built on it.
+//
+// WHY THIS IS A MODULE AND NOT A PRIVATE METHOD. It was both of those things inside
+// `FoliateController`, and it is pure — no engine state, no DOM, just a regex over a string. That
+// purity is what makes it the one place the hosted transport cannot route through the reader host:
+// `Reader.tsx:300` calls `bookmarkVisible` inside a REACT RENDER BODY, which cannot await, so on
+// WebKit the answer has to be computed in the application while the engine runs elsewhere.
+//
+// The alternatives were worse. Re-implementing the rule in the transport would put two copies of a
+// CFI parser in the codebase, and the day they disagreed a bookmark would light up in the wrong
+// chapter with nothing to point at. Pushing a precomputed visibility set from the host would make a
+// render path depend on a snapshot arriving in time.
+//
+// So it moves, exactly as `navIntent.ts` already did for the same reason: ONE copy, shared with its
+// tests, called by the controller and by the transport alike. `FoliateController.bookmarkVisible`
+// still exists and still behaves identically — it delegates here.
+
+/**
+ * The spine section of a foliate CFI: the step before `!` (or the whole inner CFI at a section
+ * boundary, which has no `!`), with any `[assertion]` stripped.
+ *
+ * Two CFIs in the same chapter share it exactly, so string equality is "same chapter".
+ */
+export function cfiSection(cfi: string | null | undefined): string | null {
+  if (!cfi) return null;
+  const m = /^epubcfi\((.*)\)$/.exec(cfi.trim());
+  const inner = m ? m[1] : cfi.trim();
+  const spine = inner.split("!")[0].replace(/\[[^\]]*\]/g, "").trim();
+  return spine || null;
+}
+
+/**
+ * Is `bookmarkCfi` in the same chapter as `currentCfi`?
+ *
+ * The bookmark marker stays lit anywhere in its chapter — top to bottom, any scroll position — and
+ * goes out only when the reader LEAVES that chapter. Section identity is what expresses that, not a
+ * whole-book fraction window.
+ */
+export function sameSection(
+  bookmarkCfi: string | null | undefined,
+  currentCfi: string | null | undefined,
+): boolean {
+  const a = cfiSection(bookmarkCfi);
+  const b = cfiSection(currentCfi);
+  return a != null && a === b;
+}

--- a/src/reader-transport/hosted.ts
+++ b/src/reader-transport/hosted.ts
@@ -1,0 +1,242 @@
+// The reader as the application sees it when the engine runs inside the reader host.
+//
+// It presents the SAME surface `FoliateController` does. That is the design: `Reader.tsx` has 107
+// call sites and none of them changes, because what differs between platforms is where the engine
+// runs, not what it looks like from outside.
+//
+// Three shapes of member, classified in `surface.ts`:
+//
+//   • most are forwarded over the port and already return a promise;
+//   • thirteen return synchronously, and are answered from a mirror the host pushes AHEAD of the
+//     question, so their signatures stay synchronous and their call sites stay untouched;
+//   • three are decided HERE, because the engine needs the answer before a round trip could return.
+//
+// Nothing re-implements engine logic. Where a decision is made on this side it calls the same shared
+// module the engine calls — `navIntent`, `cfiSection` — so the two sides cannot disagree.
+import { navIntent } from "../reader-engine/navIntent";
+import { sameSection } from "../reader-engine/cfiSection";
+import type { FoliateController } from "../reader-engine/FoliateController";
+import { CROSSING } from "./surface";
+import type { Mirror, Push, Reply, Request, RequestBody } from "./protocol";
+
+const EMPTY_MIRROR: Mirror = {
+  currentSectionIndex: 0,
+  atChapterStart: true,
+  isTtsChapterOnScreen: true,
+  hasNextSection: false,
+  openingUnderTopBar: false,
+  pdfTextQuality: null,
+  pdfRenderedScale: 1,
+  pdfHasSpeakableText: false,
+  isFixedLayout: false,
+  toc: [],
+  tocHrefSection: [],
+  ttsCursors: [],
+};
+
+/**
+ * Synchronous reads whose answer the mirror carries verbatim.
+ *
+ * Written out rather than derived. If the engine grows another synchronous member, this does not
+ * quietly start returning `undefined` for it — `readerSurface.test.ts` fails first, because the new
+ * member's shape is unforwardable and nothing classified it.
+ */
+const MIRRORED_DIRECT = {
+  currentSectionIndex: "currentSectionIndex",
+  atChapterStart: "atChapterStart",
+  isTtsChapterOnScreen: "isTtsChapterOnScreen",
+  hasNextSection: "hasNextSection",
+  openingUnderTopBar: "openingUnderTopBar",
+  pdfTextQuality: "pdfTextQuality",
+  pdfRenderedScale: "pdfRenderedScale",
+  pdfHasSpeakableText: "pdfHasSpeakableText",
+} as const satisfies Record<string, keyof Mirror>;
+
+export class HostedReader {
+  // Deliberately NOT `#private`. The proxy below has to read `handlers` and dispatch on the members
+  // declared here, and a `#name` field is unreachable from outside the class body — an earlier draft
+  // reached for one through a cast, which type-checks and is always `undefined` at run time.
+  private readonly port: MessagePort;
+  private nextId = 1;
+  private readonly pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  private mirror: Mirror = EMPTY_MIRROR;
+  readonly handlers = new Map<string, (...args: unknown[]) => unknown>();
+
+  constructor(port: MessagePort) {
+    this.port = port;
+    port.onmessage = (e: MessageEvent<Reply | Push>) => this.receive(e.data);
+    port.start();
+  }
+
+  private receive(msg: Reply | Push): void {
+    if ("kind" in msg) {
+      if (msg.kind === "state") this.mirror = msg.mirror;
+      else if (msg.kind === "event") this.handlers.get(msg.name)?.(...msg.args);
+      return;
+    }
+    const p = this.pending.get(msg.id);
+    if (!p) return;
+    this.pending.delete(msg.id);
+    if (msg.ok) p.resolve(msg.value);
+    else p.reject(new Error(msg.error ?? "the reader host refused the call"));
+  }
+
+  private send(req: RequestBody, transfer: Transferable[] = []): Promise<unknown> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.port.postMessage({ ...req, id } as Request, transfer);
+    });
+  }
+
+  /** A consequence nobody awaits. The next mirror push reports the result either way. */
+  private tell(method: string, args: unknown[] = []): void {
+    void this.send({ kind: "call", method, args }).catch(() => {});
+  }
+
+  /** Used by the proxy for every member not declared on this class. */
+  call(method: string, args: unknown[]): Promise<unknown> {
+    return this.send({ kind: "call", method, args });
+  }
+
+  // ---- opening ----------------------------------------------------------------------------------
+
+  /**
+   * The same signature the engine has, so `Reader.tsx:1218` is untouched.
+   *
+   * The application resolves the book to an `asset:` URL and can fetch it; the host cannot, and must
+   * not be able to — a filesystem route from that origin is exactly what `bookhost.rs` refuses. So
+   * the bytes are read HERE and transferred, which is also the cheaper of the two measured options
+   * (1257 ms vs 1278 ms on a 14.1 MB EPUB). `container` is ignored: the host owns its own.
+   */
+  async open(source: string, _container: HTMLElement, opts: unknown): Promise<void> {
+    const bytes = await (await fetch(source)).arrayBuffer();
+    await this.send({ kind: "open", bytes, opts }, [bytes]);
+  }
+
+  // ---- the three decisions that cannot wait ------------------------------------------------------
+
+  /**
+   * `Reader.tsx:1587` calls this in a keydown listener and uses the answer for `preventDefault()`.
+   * A promise resolves long after the browser has decided what the key does.
+   *
+   * It does not need to cross. The engine's body is `navIntent(key)`, then — for arrows on a
+   * reflowable book — the arrow callback, then a page turn. `navIntent` is the same module the engine
+   * imports, and its comment says why it exists separately: ONE copy, shared with its tests.
+   * `isFixedLayout` is mirrored. The arrow callback belongs to the application, which registered it.
+   * Only the page turn crosses, and nothing waits for it.
+   */
+  handleNavKey(key: string): boolean {
+    const intent = navIntent(key);
+    if (!intent) return false;
+    if (!this.mirror.isFixedLayout && (key === "ArrowLeft" || key === "ArrowRight")) {
+      const arrow = this.handlers.get("onArrow") as ((k: string) => boolean) | undefined;
+      if (arrow?.(key)) return true;
+    }
+    this.tell(intent === "forward" ? "forward" : "backward");
+    return true;
+  }
+
+  /**
+   * The engine asks the application whether it claimed an arrow, mid-gesture, and branches on the
+   * answer. A port cannot reply in time — so the host never asks. The callback is held here and
+   * consulted by `handleNavKey`, which is the only path that reaches it.
+   */
+  onArrow(cb: (key: string) => boolean): void {
+    this.handlers.set("onArrow", cb as (...a: unknown[]) => unknown);
+  }
+
+  /**
+   * The same shape as `onArrow`, and the harder of the two — because the engine does NOT reach this
+   * one through a method the application calls.
+   *
+   * MEASURED: `arrowCb` is invoked from exactly one place, `handleNavKey`, which the application
+   * drives — so arrows never need to cross. `spaceCb` is invoked from two keydown listeners the
+   * ENGINE attaches (FoliateController:1663, :1765), and those run in the host. A boolean cannot get
+   * back there in time.
+   *
+   * So the host does not ask. It registers its own `onSpace` that always claims the key — the engine
+   * calls `preventDefault()` and takes no further action — and pushes a `space` event here. The
+   * application's callback runs on this side, and only if it declines does a page turn cross. The
+   * outcome is the engine's own `if (spaceCb()) preventDefault(); else next();`, with the page turn
+   * one message later; nothing is re-implemented and nothing waits on a synchronous reply.
+   */
+  onSpace(cb: () => boolean): void {
+    this.handlers.set("space", ((): unknown => {
+      if (cb()) return true;
+      this.tell("forward");
+      return false;
+    }) as (...a: unknown[]) => unknown);
+  }
+
+  // ---- synchronous reads, answered from the mirror -----------------------------------------------
+
+  getToc(): unknown[] {
+    return this.mirror.toc;
+  }
+
+  /** Pure, and shared with the engine — `cfiSection.ts` records why it is computed on this side. */
+  bookmarkVisible(a: string | null | undefined, b: string | null | undefined): boolean {
+    return sameSection(a, b);
+  }
+
+  /**
+   * A lookup over the mirrored map, never a re-derivation of it. Called with an explicit list only
+   * when the panel shows a synthesised TOC, in which case the answer is the same map narrowed to the
+   * entries actually on screen.
+   */
+  tocHrefSectionMap(entries?: { href?: string }[]): Map<string, number> {
+    const full = new Map(this.mirror.tocHrefSection);
+    if (!entries) return full;
+    const out = new Map<string, number>();
+    for (const e of entries) {
+      const href = e?.href;
+      const i = href == null ? undefined : full.get(href);
+      if (href != null && i !== undefined) out.set(href, i);
+    }
+    return out;
+  }
+
+  getTtsCursor(i: number): unknown {
+    return this.mirror.ttsCursors[i] ?? null;
+  }
+
+  /** Reads the mirror for the eight members whose value it carries directly. */
+  mirrored(method: keyof typeof MIRRORED_DIRECT): unknown {
+    return this.mirror[MIRRORED_DIRECT[method]];
+  }
+}
+
+/**
+ * Present the hosted reader with the engine's own type.
+ *
+ * A `Proxy` rather than fifty-two hand-written one-line forwards. The forwards carry no decisions,
+ * and writing them out by hand invites the one that is subtly different from the rest — which is the
+ * failure mode this whole seam is trying to avoid.
+ */
+export function hostedReader(port: MessagePort): FoliateController {
+  const impl = new HostedReader(port);
+  return new Proxy(impl, {
+    get(target, prop, receiver) {
+      if (typeof prop !== "string") return Reflect.get(target, prop, receiver);
+
+      // Declared on HostedReader: the decisions, the mirrored reads with arguments, `open`.
+      if (prop in target) return Reflect.get(target, prop, receiver);
+
+      // Mirrored, answered synchronously.
+      if (prop in MIRRORED_DIRECT) {
+        return () => target.mirrored(prop as keyof typeof MIRRORED_DIRECT);
+      }
+
+      // A callback the application registers; the host pushes the event and we invoke it.
+      if (CROSSING[prop] === "callback") {
+        return (cb: (...a: unknown[]) => unknown) => {
+          target.handlers.set(prop, cb);
+        };
+      }
+
+      // Everything else is mechanical.
+      return (...args: unknown[]) => target.call(prop, args);
+    },
+  }) as unknown as FoliateController;
+}

--- a/src/reader-transport/index.ts
+++ b/src/reader-transport/index.ts
@@ -1,0 +1,70 @@
+// Which reader the application gets, and why it differs by platform.
+//
+// Windows takes the direct path: `new FoliateController()`, the same object it has always
+// constructed, running in the application's own document. There is no measured defect there and
+// nothing about the hosted path would improve it.
+//
+// WebKit takes the hosted path, for one measured reason: WebKitGTK does not deliver pointer events
+// into an iframe sandboxed `allow-same-origin` without `allow-scripts`, and Blink does. Giving book
+// content `allow-scripts` is only safe when the document it can reach holds nothing — which is what
+// the reader host is.
+//
+// This is the ONLY place the platform is consulted on the frontend. Everything downstream — all 107
+// call sites in `Reader.tsx` — sees the same surface either way.
+import { FoliateController } from "../reader-engine/FoliateController";
+import { hostedReader } from "./hosted";
+
+/**
+ * Is this a WebView that needs the reader host?
+ *
+ * Asked of the ENGINE, not of the operating system. What matters is the input-delivery behaviour of
+ * the WebView, and that is a property of WebKit rather than of Linux or macOS: a Chromium-based
+ * WebView on Linux would not need this, and asking "is this Linux?" would give it the host anyway.
+ * WebKit is identified by the absence of Chrome/Chromium in a WebKit user agent — Blink's UA also
+ * contains "AppleWebKit", so the negative is the discriminator.
+ */
+export function needsReaderHost(ua: string = navigator.userAgent): boolean {
+  return /AppleWebKit/.test(ua) && !/Chrome|Chromium|Edg\//.test(ua);
+}
+
+/** The host document, mounted once and kept for the life of the window. */
+let hostFrame: HTMLIFrameElement | null = null;
+
+function mountHost(): Promise<MessagePort> {
+  return new Promise((resolve, reject) => {
+    const frame = document.createElement("iframe");
+    hostFrame = frame;
+    frame.setAttribute("title", "reader");
+    frame.style.cssText = "position:absolute;inset:0;width:100%;height:100%;border:0";
+
+    const onMessage = (e: MessageEvent) => {
+      if (e.source !== frame.contentWindow) return; // `e.origin` cannot authenticate; `e.source` can
+      if (!(e.data as { __sardHostReady?: boolean })?.__sardHostReady) return;
+      removeEventListener("message", onMessage);
+      const channel = new MessageChannel();
+      frame.contentWindow?.postMessage({ __sardHostInit: true }, "*", [channel.port2]);
+      resolve(channel.port1);
+    };
+    addEventListener("message", onMessage);
+    frame.addEventListener("error", () => reject(new Error("the reader host failed to load")));
+    frame.src = "sardhost://localhost/";
+    document.body.appendChild(frame);
+  });
+}
+
+/**
+ * The reader for this platform.
+ *
+ * Windows resolves immediately with the object it has always used. The hosted path has to wait for
+ * the host document to announce itself, which is why this is asynchronous on both — a signature that
+ * differs by platform would push the difference into the caller.
+ */
+export async function createReader(): Promise<FoliateController> {
+  if (!needsReaderHost()) return new FoliateController();
+  return hostedReader(await mountHost());
+}
+
+/** The frame the host runs in, for the reading area to place. Null on the direct path. */
+export function readerHostFrame(): HTMLIFrameElement | null {
+  return hostFrame;
+}

--- a/src/reader-transport/protocol.ts
+++ b/src/reader-transport/protocol.ts
@@ -1,0 +1,111 @@
+// The wire between the application and the reader host.
+//
+// Everything here has to survive structured cloning, because that is all a `MessagePort` carries.
+// That single constraint is why the shapes are this plain: no class instances, no DOM nodes, no
+// functions. Where the engine's own signature cannot satisfy it, `surface.ts` records the exception
+// and the transport handles it explicitly rather than letting it fail at run time on one platform.
+
+/** Sent when the host document has loaded and is ready to be given a port. */
+export interface HostReady {
+  __sardHostReady: true;
+}
+
+/** The application's half of the handshake; carries `port2` in the transfer list. */
+export interface HostInit {
+  __sardHostInit: true;
+}
+
+/** A mechanically forwarded method call. */
+export interface CallMsg {
+  id: number;
+  kind: "call";
+  method: string;
+  args: unknown[];
+}
+
+/** Opening a book: the bytes travel as a transferable, not as a copy. */
+export interface OpenMsg {
+  id: number;
+  kind: "open";
+  bytes: ArrayBuffer;
+  opts: unknown;
+}
+
+export type Request = CallMsg | OpenMsg;
+
+/**
+ * A request before the transport stamps its id on it.
+ *
+ * Distributed over the union deliberately. `Omit<Request, "id">` collapses a union to the keys its
+ * members SHARE, so `method` and `bytes` both disappear and every construction site fails to
+ * type-check — which is what happened first.
+ */
+export type RequestBody = Omit<CallMsg, "id"> | Omit<OpenMsg, "id">;
+
+/** A reply to one request. `value` is whatever the method returned, after cloning. */
+export interface Reply {
+  id: number;
+  ok: boolean;
+  value?: unknown;
+  error?: string;
+}
+
+/**
+ * Everything the application can read SYNCHRONOUSLY, pushed by the host after every command.
+ *
+ * WHY A SNAPSHOT AT ALL. Thirteen engine members return a value synchronously, and the application
+ * reads them from places that cannot await — a React render body, a keydown handler whose answer
+ * drives `preventDefault()`. Making them asynchronous would change their signatures and with them
+ * all 107 call sites in `Reader.tsx`, which is precisely the churn this seam exists to avoid. So the
+ * host sends the answers ahead of the questions.
+ *
+ * The arg-taking reads are represented as their FULL domain where the domain is bounded — the TTS
+ * cursors as an array, the TOC map as entries — rather than as a function, because a function cannot
+ * cross and re-deriving one in the application would be a second copy of engine logic.
+ */
+export interface Mirror {
+  currentSectionIndex: number;
+  atChapterStart: boolean;
+  isTtsChapterOnScreen: boolean;
+  hasNextSection: boolean;
+  openingUnderTopBar: boolean;
+  pdfTextQuality: unknown;
+  pdfRenderedScale: number;
+  pdfHasSpeakableText: boolean;
+  /** Needed by `handleNavKey`, which must decide locally. */
+  isFixedLayout: boolean;
+  toc: unknown[];
+  /** `tocHrefSectionMap()` with its default argument, as entries — a Map does not survive cloning. */
+  tocHrefSection: [string, number][];
+  /** `getTtsCursor(i)` for every retained unit; the application indexes into it. */
+  ttsCursors: (unknown | null)[];
+}
+
+/** An engine event the application registered a callback for. */
+export interface EventMsg {
+  kind: "event";
+  name: string;
+  args: unknown[];
+}
+
+/** A pushed mirror. */
+export interface StateMsg {
+  kind: "state";
+  mirror: Mirror;
+}
+
+export type Push = EventMsg | StateMsg;
+
+/** The callback-registering members the host pushes events for. */
+export const EVENT_NAMES = [
+  "onSelection",
+  "onShowAnnotation",
+  "onActivity",
+  "onZoomIntent",
+  "onScrollIntent",
+  "onReadingRedraw",
+  "onRelocate",
+  "onReferenceHit",
+] as const;
+
+export type EventName = (typeof EVENT_NAMES)[number];


### PR DESCRIPTION
The reader the application talks to when the engine runs in the host. It presents the same surface `FoliateController` does, so `Reader.tsx`'s 107 call sites are untouched.

**Nothing is wired yet** — no caller constructs this, so no reader behaviour changes on any platform.

## The three synchronous decisions

Each is made on the side that already owns what it needs, and none is re-implemented.

**`handleNavKey`** drives `preventDefault()` from a keydown listener. Its decision is `navIntent(key)` — the same module the engine imports, which exists separately *precisely so there is one copy* — plus a mirrored boolean plus a callback the application registered. Only the page turn crosses, unawaited.

**`onArrow`** needed nothing further. **MEASURED:** `arrowCb` is invoked from exactly one place, `handleNavKey`, which the application drives.

**`onSpace` — the measurement changed the design.** `spaceCb` is invoked from two keydown listeners the *engine* attaches (`FoliateController:1663`, `:1765`), and those run host-side. No boolean can get back in time. So the host does not ask: it claims the key, the engine calls `preventDefault()` and stops, and an event is pushed. The application's callback runs on this side; only a *declined* space sends a page turn across. Same outcome as the engine's own `if (spaceCb()) preventDefault(); else next();`, one message later.

## The one engine change, and why it was unavoidable

`bookmarkVisible` moves to `src/reader-engine/cfiSection.ts`. It is read from a **React render body** (`Reader.tsx:300`), which cannot await, and it is **pure** — `cfiSection` was already documented "Pure; no engine call." The alternatives were a second copy of a CFI parser, or a render path waiting on a snapshot to arrive. `FoliateController` still declares the method and delegates; same pattern as `navIntent.ts`.

**Windows evidence with it in place: both baselines byte-identical, paged included.**

## Verification

| | |
|---|---|
| `preseam-scrolled` | **byte-identical** |
| `preseam-paged` | **byte-identical** |
| `tsc` | clean |
| Unit suite | 312 passed / 11 skipped |
| Windows-target `dist/reader-host` | **absent** |
| production-tree / production-content gates | pass |

## Not done in this PR

The **host half** — the dispatcher, the mirror push, the event push — is not implemented, and `Reader.tsx:140` is unchanged. Gates 4, 5 and 6 (Linux runtime with a real EPUB, security re-check after wiring, full surface verification) cannot be met until both halves exist, so they are the next gate rather than claims made here.