### PR TITLE
Wire the reader through the hosted transport on WebKit

### DIFF
--- a/src/features/reader/Reader.tsx
+++ b/src/features/reader/Reader.tsx
@@ -5,6 +5,9 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 
 import { setBookCssMode } from "../../reader-engine/FoliateController";
 import { FoliateController, type SearchHit, type SelectionInfo, type TocEntry } from "../../reader-engine/FoliateController";
+// The reader for THIS platform: the same object as always on Windows, the hosted transport on
+// WebKit. This import is the only place the reader's construction differs.
+import { createReader, needsReaderHost } from "../../reader-transport";
 import { PhotoComposer } from "../photo/PhotoComposer";
 import type { CardData } from "../photo/photo";
 import { useReader } from "../../reader-engine/store";
@@ -137,7 +140,16 @@ export function Reader({
   const { t, lang, dir: uiDir } = useI18n();
   const stageRef = useRef<HTMLDivElement>(null);
   const ctrlRef = useRef<FoliateController | null>(null);
-  if (!ctrlRef.current) ctrlRef.current = new FoliateController();
+  // WINDOWS IS UNCHANGED: the same synchronous construction, available on the first render exactly as
+  // before. `needsReaderHost()` is false there, so this line runs and the ref below is never used.
+  //
+  // On WebKit the reader cannot be built synchronously — the reader host is a document that has to
+  // load and hand back a port first. Rather than make every reader of `ctrlRef` cope with null, the
+  // promise is created once here and awaited at the ONE place that needs the object before it can do
+  // anything: `openBook`. Everything else already guards with `?.`.
+  if (!ctrlRef.current && !needsReaderHost()) ctrlRef.current = new FoliateController();
+  const hostedRef = useRef<Promise<FoliateController> | null>(null);
+  if (!ctrlRef.current && !hostedRef.current) hostedRef.current = createReader();
   // A dev/debug surface reachable from DevTools without shipping any UI — the same convention as
   // `window.__sardTtsStats`. Lets the TTS-tracking probe measure the REAL pipeline instead of a
   // re-implementation of it that could drift.
@@ -503,6 +515,11 @@ export function Reader({
         initialStyle = { ...initialStyle, flowMode: "scrolled" };
       }
 
+      // On the hosted path this is the first moment the reader is actually needed, and the awaits
+      // above have already given the host time to load. On Windows `ctrlRef.current` was assigned
+      // during the first render and this resolves to it without awaiting anything.
+      if (!ctrlRef.current && hostedRef.current) ctrlRef.current = await hostedRef.current;
+      if (stale()) return;
       const ctrl = ctrlRef.current!;
       ctrl.onRelocate(({ cfi, fraction, chapterLabel, chapterHref, location, pageLabel }) => {
         // WP-4F: `location`/`pageLabel` are foliate's own position data, which used to be dropped here.

--- a/src/reader-host/main.ts
+++ b/src/reader-host/main.ts
@@ -8,125 +8,224 @@
 //
 // The resolution is enclosure, not surrender. Book content gets `allow-scripts` again — but the
 // document it can reach is THIS one, served from `sardhost://`, which has no Tauri API, no
-// application document, no database handle and no secret. D30's intent ("a book must not reach
-// anything that matters") holds; only the mechanism moved from the sandbox attribute to the origin.
+// application document, no database handle and no secret. D30's intent holds; only the mechanism
+// moved from the sandbox attribute to the origin.
 //
 // MEASURED from inside this origin, real Tauri app, real WebKitGTK: `parent.__TAURI_INTERNALS__`,
 // `parent.document`, `parent.location.href` and every `top.*` equivalent raise SecurityError, the
-// application cannot read back into here, and a cross-origin fetch raises a `connect-src` violation.
+// application cannot read back in, and a cross-origin fetch raises a `connect-src` violation.
 //
-// This file is built by `scripts/build-reader-host.mjs` into ONE self-contained bundle and is not
-// emitted at all for a Windows target.
+// Built by `scripts/build-reader-host.mjs` into ONE self-contained bundle, and not emitted at all
+// for a Windows target.
 import { FoliateController } from "../reader-engine/FoliateController";
+import { EVENT_NAMES, type Mirror, type Reply, type Request } from "../reader-transport/protocol";
 
 // ---------------------------------------------------------------------------------------------
 // The section sandbox. Set BEFORE the engine can create a single iframe.
 // ---------------------------------------------------------------------------------------------
-// Read by the two vendored call sites (paginator.js, fixed-layout.js — VENDOR patch 1b). Setting it
-// here rather than in the engine keeps the decision with the only code that knows where it is: this
-// bundle exists solely on the hosted path, so its presence IS the condition. Nothing sets it in the
-// application origin, where the fallback keeps today's exact value.
+// Read by the two vendored call sites (VENDOR patch 1b). Setting it here rather than in the engine
+// keeps the decision with the only code that knows where it is: this bundle exists solely on the
+// hosted path, so its presence IS the condition. Nothing sets it in the application origin, where
+// the fallback keeps today's exact value.
 (globalThis as { __sardSectionSandbox?: string }).__sardSectionSandbox =
   "allow-same-origin allow-scripts";
 
-// ---------------------------------------------------------------------------------------------
-// The command channel.
-// ---------------------------------------------------------------------------------------------
-// A MessagePort held in a closure and never written to any global. MEASURED: a port left reachable
-// on the global was hijacked in a proof-of-concept and its forged messages were accepted on the
-// trusted channel, so reachability is the whole property — `messagePortsOnGlobal: none` is a Step 1
-// exit criterion, and this is what keeps it true.
-//
-// The handshake is authenticated on `e.source`, not `e.origin`. MEASURED: `e.origin` cannot
-// distinguish the application from book content that forged a message, and `e.source` can.
-type Cmd =
-  | { id: number; cmd: "open"; bytes: ArrayBuffer; opts: OpenArgs }
-  | { id: number; cmd: "navKey"; key: string }
-  | { id: number; cmd: "state" };
-
-// Only the fields the host needs to open a book. Deliberately not a re-declaration of the engine's
-// OpenOptions: this is the wire, and a wire that mirrors an internal type drifts with it silently.
-interface OpenArgs {
-  style: unknown;
-  theme?: unknown;
-  flags?: unknown;
-  dir?: string | null;
-  flow?: "scrolled" | "paged";
-  resumeCfi?: string | null;
-  resumeFraction?: number | null;
-}
-
 const controller = new FoliateController();
-let stage: HTMLElement | null = null;
-let bookUrl: string | null = null;
 
+let stage: HTMLElement | null = null;
 function ensureStage(): HTMLElement {
-  if (stage) return stage;
+  if (stage?.isConnected) return stage;
   const el = document.createElement("div");
-  el.className = "page-host"; // the selector the engine and the harness both look for
+  el.className = "page-host"; // the selector the engine's own callers look for
   document.body.replaceChildren(el);
   stage = el;
   return el;
 }
 
-async function run(msg: Cmd): Promise<unknown> {
-  switch (msg.cmd) {
-    case "open": {
-      // The bytes arrive transferred, not copied. MEASURED equivalent to serving the file from the
-      // host origin (1257 ms vs 1278 ms on a 14.1 MB EPUB), and chosen over it because serving a
-      // file would give this origin a filesystem route — the one thing bookhost.rs is built to
-      // refuse, and what its `/library/book.epub -> 404` test asserts.
-      //
-      // A blob URL rather than a File: foliate's `makeBook` sniffs `%PDF-` from the bytes
-      // themselves, so format detection does not depend on a filename and the engine needs no
-      // change to accept this. The three places the engine matches `.pdf` against the source are
-      // diagnostic labels only, compiled out of a release build.
-      if (bookUrl) URL.revokeObjectURL(bookUrl);
-      bookUrl = URL.createObjectURL(new Blob([msg.bytes]));
-      await controller.open(bookUrl, ensureStage(), msg.opts as never);
-      return { opened: true };
-    }
-    // The engine has no next()/prev(); `handleNavKey` IS its navigation entry point, and it is the
-    // one the application already calls (Reader.tsx:1587). Forwarding the key rather than inventing
-    // a next/prev pair keeps the hosted surface the same surface, so nothing here has to decide what
-    // a page turn means — including which direction "forward" is in an RTL book.
-    case "navKey":
-      return { handled: controller.handleNavKey(msg.key) };
-    case "state":
-      return {
-        section: controller.currentSectionIndex(),
-        toc: controller.getToc().length,
-        atChapterStart: controller.atChapterStart(),
-      };
+let bookUrl: string | null = null;
+
+// ---------------------------------------------------------------------------------------------
+// The mirror.
+// ---------------------------------------------------------------------------------------------
+// Thirteen engine members return synchronously, and the application reads several of them from
+// places that cannot await. Their answers are pushed AHEAD of the question so their signatures — and
+// therefore all 107 call sites — stay exactly as they are.
+//
+// A read that throws must not take the whole snapshot with it. Before a book is open, several of
+// these have nothing to answer from, and a snapshot that fails to build is a reader that never gets
+// its first state.
+function safe<T>(read: () => T, fallback: T): T {
+  try {
+    return read();
+  } catch {
+    return fallback;
   }
 }
 
+/**
+ * How far to walk the TTS cursors.
+ *
+ * `getTtsCursor(i)` answers null past the end and the engine exposes no count, so the walk stops at
+ * the first null. The cap is a guard against a pathological chapter, not a real limit: the longest
+ * corpus chapter is far below it, and exceeding it costs a fallback rather than a wrong answer.
+ */
+const TTS_CURSOR_CAP = 4000;
+
+function buildMirror(): Mirror {
+  const cursors: (unknown | null)[] = [];
+  for (let i = 0; i < TTS_CURSOR_CAP; i++) {
+    const c = safe(() => controller.getTtsCursor(i), null);
+    if (c == null) break;
+    cursors.push(c);
+  }
+  return {
+    currentSectionIndex: safe(() => controller.currentSectionIndex(), 0),
+    atChapterStart: safe(() => controller.atChapterStart(), true),
+    isTtsChapterOnScreen: safe(() => controller.isTtsChapterOnScreen(), true),
+    hasNextSection: safe(() => controller.hasNextSection(), false),
+    openingUnderTopBar: safe(() => controller.openingUnderTopBar(), false),
+    pdfTextQuality: safe(() => controller.pdfTextQuality() as unknown, null),
+    pdfRenderedScale: safe(() => controller.pdfRenderedScale(), 1),
+    pdfHasSpeakableText: safe(() => controller.pdfHasSpeakableText(), false),
+    isFixedLayout: safe(() => controller.isFixedLayout, false),
+    toc: safe(() => controller.getToc() as unknown[], []),
+    // A Map does not survive structured cloning; entries do.
+    tocHrefSection: safe(() => [...controller.tocHrefSectionMap()], []),
+    ttsCursors: cursors,
+  };
+}
+
+// ---------------------------------------------------------------------------------------------
+// The channel.
+// ---------------------------------------------------------------------------------------------
+// The port is held in a closure and never written to any global. MEASURED: a port left reachable on
+// the global was hijacked in a proof-of-concept and its forged messages were accepted on the trusted
+// channel, so reachability is the whole property — "no MessagePort on the host global" is an exit
+// criterion, and this is what keeps it true.
+let channel: MessagePort | null = null;
+
+function push(msg: unknown): void {
+  channel?.postMessage(msg);
+}
+
+function pushState(): void {
+  push({ kind: "state", mirror: buildMirror() });
+}
+
+/**
+ * Strip anything a structured clone would refuse.
+ *
+ * `SelectionInfo` carries an optional live `Range` (RAWY-227) and a Range cannot cross. Posting the
+ * object untouched would throw a DataCloneError and lose the WHOLE event, so the selection would
+ * simply never reach the application — a silent, total failure of the selection toolbar.
+ *
+ * Dropping the range is not a behaviour change: the field is optional and its absence is an
+ * established path. The engine's own comment says a 24-character normalised text match is the
+ * fallback, with the chapter top as last resort, and `Reader.tsx:1822` implements exactly that.
+ */
+function cloneable(value: unknown): unknown {
+  if (value == null || typeof value !== "object") return value;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (v instanceof Range || v instanceof Node || typeof v === "function") continue;
+    out[k] = typeof v === "object" && v !== null ? cloneable(v) : v;
+  }
+  return out;
+}
+
+function registerEvents(): void {
+  for (const name of EVENT_NAMES) {
+    const register = (controller as unknown as Record<string, (cb: (...a: unknown[]) => void) => void>)[name];
+    if (typeof register !== "function") continue;
+    register.call(controller, (...args: unknown[]) => {
+      push({ kind: "event", name, args: args.map(cloneable) });
+      // A callback firing means engine state may have moved — a relocate changes the section, a
+      // selection can change what is on screen. Pushing here is what keeps the mirror's synchronous
+      // answers true between commands.
+      pushState();
+    });
+  }
+
+  // `onSpace` is NOT one of the pushed callbacks, and the difference is measured rather than stylistic.
+  //
+  // `spaceCb` is invoked from two keydown listeners the ENGINE attaches (FoliateController:1663,
+  // :1765), and those run here. The engine wants a boolean back immediately and branches on it; a
+  // MessagePort cannot answer in time.
+  //
+  // So the host claims the key. Returning true makes the engine call `preventDefault()` and take no
+  // further action, which is precisely the branch we want it to take, and the application decides
+  // what the key MEANT on its own side. If its callback declines, it sends a page turn back. The
+  // outcome is the engine's own `if (spaceCb()) preventDefault(); else next();` with the turn one
+  // message later — not a synchronous answer faked across an asynchronous boundary.
+  controller.onSpace(() => {
+    push({ kind: "event", name: "space", args: [] });
+    return true;
+  });
+}
+
+// ---------------------------------------------------------------------------------------------
+// The dispatcher.
+// ---------------------------------------------------------------------------------------------
+async function run(msg: Request): Promise<unknown> {
+  if (msg.kind === "open") {
+    // The bytes arrive transferred, not copied. MEASURED equivalent to serving the file from this
+    // origin (1257 ms vs 1278 ms on a 14.1 MB EPUB), and chosen over it because serving a file would
+    // give this origin a filesystem route — the one thing `bookhost.rs` is built to refuse.
+    //
+    // A blob URL rather than a File: foliate's `makeBook` sniffs `%PDF-` from the bytes themselves,
+    // so format detection does not depend on a filename and the engine needs no change to accept it.
+    if (bookUrl) URL.revokeObjectURL(bookUrl);
+    bookUrl = URL.createObjectURL(new Blob([msg.bytes]));
+    await controller.open(bookUrl, ensureStage(), msg.opts as never);
+    return { opened: true };
+  }
+
+  const fn = (controller as unknown as Record<string, unknown>)[msg.method];
+  if (typeof fn !== "function") {
+    // Loud, and named. A silent `undefined` here would surface as an unrelated failure somewhere in
+    // the reader, on one platform only, with nothing pointing back to the transport.
+    throw new Error(`the reading engine has no method "${msg.method}"`);
+  }
+  const value = await (fn as (...a: unknown[]) => unknown).apply(controller, msg.args);
+  return cloneable(value);
+}
+
 function attach(port: MessagePort): void {
-  port.onmessage = (e: MessageEvent<Cmd>) => {
+  channel = port;
+  port.onmessage = (e: MessageEvent<Request>) => {
     const msg = e.data;
     void (async () => {
+      const reply: Reply = { id: msg.id, ok: true };
       try {
-        port.postMessage({ id: msg.id, ok: true, value: await run(msg) });
+        reply.value = await run(msg);
       } catch (err) {
-        port.postMessage({ id: msg.id, ok: false, error: String(err) });
+        reply.ok = false;
+        reply.error = err instanceof Error ? err.message : String(err);
       }
+      port.postMessage(reply);
+      // After every command, without exception. The mirror is what makes the application's
+      // synchronous reads true, and a command that moved the engine without refreshing it would
+      // leave the reader answering from a state that no longer exists.
+      pushState();
     })();
   };
   port.start();
+  registerEvents();
+  pushState();
+  port.postMessage({ id: 0, ok: true, value: { ready: true, origin: location.origin } } satisfies Reply);
 }
 
 addEventListener("message", (e: MessageEvent) => {
-  // `e.source` is the only trustworthy discriminator here — see above. Book content lives in a
+  // `e.source` is the only trustworthy discriminator. MEASURED: `e.origin` cannot distinguish the
+  // application from book content that forged a message, and `e.source` can. Book content lives in a
   // descendant frame, so it can never satisfy this.
   if (e.source !== parent) return;
-  const data = e.data as { __sardHostInit?: boolean } | null;
-  if (!data?.__sardHostInit) return;
+  if (!(e.data as { __sardHostInit?: boolean })?.__sardHostInit) return;
   const port = e.ports[0];
-  if (!port) return;
+  if (!port || channel) return; // one channel, claimed once
   attach(port);
-  port.postMessage({ id: 0, ok: true, value: { ready: true, origin: location.origin } });
 });
 
-// Tell the application the host is live and listening. It cannot be told over the port, because the
-// port is what this announces the readiness to send.
+// Tell the application the host is live. It cannot be told over the port, because the port is what
+// this announces the readiness to send.
 parent.postMessage({ __sardHostReady: true }, "*");

--- a/src/reader-host/main.ts
+++ b/src/reader-host/main.ts
@@ -125,10 +125,22 @@ function pushState(): void {
  */
 function cloneable(value: unknown): unknown {
   if (value == null || typeof value !== "object") return value;
+
+  // ARRAYS STAY ARRAYS. Rebuilding one through `Object.entries` produces `{0:…,1:…}` — no `.length`,
+  // no iteration, no `map`. MEASURED on WebKitGTK: `getCurrentChapterSentences` came back as an
+  // object and `.length` was undefined, so a caller counting sentences silently got nothing. Every
+  // forwarded method that returns a list was affected.
+  if (Array.isArray(value)) return value.map((v) => cloneable(v));
+
+  // A Map does not survive structured cloning either; entries do, and `tocHrefSectionMap` already
+  // travels that way in the mirror.
+  if (value instanceof Map) return [...value].map(([k, v]) => [cloneable(k), cloneable(v)]);
+  if (value instanceof Set) return [...value].map((v) => cloneable(v));
+
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
     if (v instanceof Range || v instanceof Node || typeof v === "function") continue;
-    out[k] = typeof v === "object" && v !== null ? cloneable(v) : v;
+    out[k] = cloneable(v);
   }
   return out;
 }

--- a/src/reader-transport/hosted.ts
+++ b/src/reader-transport/hosted.ts
@@ -220,6 +220,16 @@ export function hostedReader(port: MessagePort): FoliateController {
     get(target, prop, receiver) {
       if (typeof prop !== "string") return Reflect.get(target, prop, receiver);
 
+      // `then` MUST NOT be manufactured, and this is not a hypothetical.
+      //
+      // `createReader()` is async, so returning this proxy makes the runtime ask whether it is a
+      // thenable — by reading `.then`. The catch-all below happily produced a forwarding function,
+      // the runtime called it with `(resolve, reject)`, and the transport tried to postMessage two
+      // FUNCTIONS. MEASURED on WebKitGTK: `DataCloneError: The object can not be cloned`, thrown
+      // inside `createReader()` before a single reader call had been made, as an unhandled rejection
+      // with nothing pointing at the cause. `catch` and `finally` are refused for the same reason.
+      if (prop === "then" || prop === "catch" || prop === "finally") return undefined;
+
       // Declared on HostedReader: the decisions, the mirrored reads with arguments, `open`.
       if (prop in target) return Reflect.get(target, prop, receiver);
 


### PR DESCRIPTION
The host half of the seam and the single construction point that chooses between the two paths. **Measured end to end on real WebKitGTK: 15 PASS · 0 FAIL · 0 UNKNOWN.**

## Runtime gate — the real reader, a real EPUB, a genuine X11 click

| | |
|---|---|
| open through the transport | ✅ |
| TOC crossed | 8 entries, href map 8 |
| mirrored synchronous reads | `section=1`, `atChapterStart=true`, … |
| CFI / bookmark rule | same-section `true`, other-section `false` |
| `handleNavKey` decided locally | arrow `true`, unmapped `false` |
| arrow callback consulted app-side | asked 1× |
| events pushed host → app | `onRelocate` 11, `onSelection` 3, `onActivity` 5 |
| async forward returned real data | **121 sentences** |
| navigation moved the engine | section 0 → 1 |
| real X11 input into the section | **6 genuine pointer events** |
| Tauri internals / app document / secrets | all `SecurityError` |
| filesystem, library, database | 404 |
| cross-origin fetch | refused |
| MessagePort on host global | `none` |

## Two real bugs the gate found in my code

**The proxy pretended to be a promise.** `createReader()` is async, so returning the proxy made the runtime read `.then`; the catch-all forwarder manufactured a method, the runtime called it with `(resolve, reject)`, and the transport tried to postMessage two functions. `DataCloneError` inside `createReader()` before a single reader call — an unhandled rejection with nothing pointing at the cause.

**The clone sanitiser destroyed arrays.** Rebuilding objects through `Object.entries` turns an array into `{0:…,1:…}` — no `length`, no iteration. `getCurrentChapterSentences` came back as an object and a caller counting sentences silently got nothing. Maps and Sets handled explicitly for the same reason.

Neither would have been caught by typechecking, and both were silent rather than loud.

## `onSpace` keeps its measured shape

The host claims the key so the engine calls `preventDefault()` and stops, then pushes an event; the application's callback runs app-side and only a *declined* space sends a page turn back. No boolean is faked across an asynchronous boundary.

## Windows

| | |
|---|---|
| `preseam-scrolled` | **byte-identical** |
| `preseam-paged` | **byte-identical** |
| interaction gate | no problem detected |
| lifecycle | all 9 guarantees hold |
| Windows-target `dist/reader-host` | **absent** |
| Unit suite | 312 / 11 skipped |

Windows constructs the reader exactly as before, synchronously, on the first render. Two call sites changed in `Reader.tsx`, not one: `openBook` asserts the controller is present and on the hosted path it would not yet be. The other 105 are untouched.

**A byte-identity failure I investigated rather than dismissed:** both baselines initially reported ~28 differences. The harness's own config guard named the cause — `arabicFont: TheYearofTheCamel → thmanyahserifdisplay`. My earlier `pagination`/`lifecycle` harness runs had changed the owner's reading style; those scripts don't snapshot the DB the way `byte-identity` does. Restoring that one setting returned both baselines to byte-identical with nothing else touched.