### PR TITLE
Close the remaining transport gaps: search, getters, and the feature gates

### DIFF
--- a/src/reader-host/main.ts
+++ b/src/reader-host/main.ts
@@ -44,6 +44,9 @@ function ensureStage(): HTMLElement {
 
 let bookUrl: string | null = null;
 
+// The in-flight search, so an abort from the application can reach it.
+let searchAbort: AbortController | null = null;
+
 // ---------------------------------------------------------------------------------------------
 // The mirror.
 // ---------------------------------------------------------------------------------------------
@@ -190,6 +193,24 @@ async function run(msg: Request): Promise<unknown> {
     bookUrl = URL.createObjectURL(new Blob([msg.bytes]));
     await controller.open(bookUrl, ensureStage(), msg.opts as never);
     return { opened: true };
+  }
+
+  // Search reports progress WHILE it runs, and its callbacks cannot cross. The application keeps
+  // them; the host supplies its own and pushes each batch, so hits still arrive progressively.
+  if (msg.method === "searchBook") {
+    searchAbort?.abort();
+    searchAbort = new AbortController();
+    return cloneable(
+      await controller.searchBook(String(msg.args[0] ?? ""), {
+        signal: searchAbort.signal,
+        onProgress: (f) => push({ kind: "event", name: "search-progress", args: [f] }),
+        onBatch: (hits) => push({ kind: "event", name: "search-batch", args: [cloneable(hits)] }),
+      }),
+    );
+  }
+  if (msg.method === "__searchAbort") {
+    searchAbort?.abort();
+    return { aborted: true };
   }
 
   const fn = (controller as unknown as Record<string, unknown>)[msg.method];

--- a/src/reader-host/main.ts
+++ b/src/reader-host/main.ts
@@ -91,6 +91,13 @@ function buildMirror(): Mirror {
     pdfRenderedScale: safe(() => controller.pdfRenderedScale(), 1),
     pdfHasSpeakableText: safe(() => controller.pdfHasSpeakableText(), false),
     isFixedLayout: safe(() => controller.isFixedLayout, false),
+    isScrolled: safe(() => controller.isScrolled, true),
+    readingScrollTop: safe(() => controller.readingScrollTop, 0),
+    pdfPageCount: safe(() => controller.pdfPageCount, 0),
+    furthestPosition: safe(() => controller.furthestPosition, null),
+    dir: safe(() => controller.dir, undefined),
+    title: safe(() => controller.title, undefined),
+    author: safe(() => controller.author, undefined),
     toc: safe(() => controller.getToc() as unknown[], []),
     // A Map does not survive structured cloning; entries do.
     tocHrefSection: safe(() => [...controller.tocHrefSectionMap()], []),

--- a/src/reader-transport/hosted.ts
+++ b/src/reader-transport/hosted.ts
@@ -169,6 +169,30 @@ export class HostedReader {
     }) as (...a: unknown[]) => unknown);
   }
 
+  // ---- search: results arrive while it runs ------------------------------------------------------
+
+  /**
+   * `searchBook(query, { signal, onProgress, onBatch })` cannot be forwarded as written — two
+   * functions and an AbortSignal, none of them cloneable.
+   *
+   * The callbacks stay on this side, where the application put them. Only the query crosses; the
+   * host runs the search with callbacks of its own and pushes each batch back, so hits still appear
+   * progressively instead of all at the end. An abort crosses as a consequence, not as a signal.
+   */
+  searchBook(
+    query: string,
+    opts: { signal?: AbortSignal; onProgress?: (f: number) => void; onBatch?: (h: unknown[]) => void } = {},
+  ): Promise<unknown[]> {
+    if (opts.onProgress) this.handlers.set("search-progress", opts.onProgress as (...a: unknown[]) => unknown);
+    if (opts.onBatch) this.handlers.set("search-batch", opts.onBatch as (...a: unknown[]) => unknown);
+    opts.signal?.addEventListener("abort", () => this.tell("__searchAbort"), { once: true });
+    return this.send({ kind: "call", method: "searchBook", args: [query] }).then((v) => {
+      this.handlers.delete("search-progress");
+      this.handlers.delete("search-batch");
+      return (v ?? []) as unknown[];
+    });
+  }
+
   // ---- synchronous reads, answered from the mirror -----------------------------------------------
 
   getToc(): unknown[] {

--- a/src/reader-transport/hosted.ts
+++ b/src/reader-transport/hosted.ts
@@ -29,6 +29,13 @@ const EMPTY_MIRROR: Mirror = {
   pdfRenderedScale: 1,
   pdfHasSpeakableText: false,
   isFixedLayout: false,
+  isScrolled: true,
+  readingScrollTop: 0,
+  pdfPageCount: 0,
+  furthestPosition: null,
+  dir: undefined,
+  title: undefined,
+  author: undefined,
   toc: [],
   tocHrefSection: [],
   ttsCursors: [],
@@ -51,6 +58,18 @@ const MIRRORED_DIRECT = {
   pdfRenderedScale: "pdfRenderedScale",
   pdfHasSpeakableText: "pdfHasSpeakableText",
 } as const satisfies Record<string, keyof Mirror>;
+
+/** The engine's public getters, read as properties and therefore always served from the mirror. */
+const GETTERS = [
+  "isFixedLayout",
+  "isScrolled",
+  "readingScrollTop",
+  "pdfPageCount",
+  "furthestPosition",
+  "dir",
+  "title",
+  "author",
+] as const;
 
 export class HostedReader {
   // Deliberately NOT `#private`. The proxy below has to read `handlers` and dispatch on the members
@@ -225,6 +244,11 @@ export class HostedReader {
     return this.mirror.ttsCursors[i] ?? null;
   }
 
+  /** A mirrored value read as a property rather than called. */
+  mirrorValue(key: keyof Mirror): unknown {
+    return this.mirror[key];
+  }
+
   /** Reads the mirror for the eight members whose value it carries directly. */
   mirrored(method: keyof typeof MIRRORED_DIRECT): unknown {
     return this.mirror[MIRRORED_DIRECT[method]];
@@ -256,6 +280,14 @@ export function hostedReader(port: MessagePort): FoliateController {
 
       // Declared on HostedReader: the decisions, the mirrored reads with arguments, `open`.
       if (prop in target) return Reflect.get(target, prop, receiver);
+
+      // GETTERS are read, not called. Returning a forwarding function for one is not a slow answer,
+      // it is a wrong VALUE: `ctrl.isFixedLayout` came back as a function and every consumer saw a
+      // truthy object. MEASURED on WebKitGTK — the PDF path reported `undefined` because
+      // JSON.stringify of a function is undefined.
+      if ((GETTERS as readonly string[]).includes(prop)) {
+        return target.mirrorValue(prop as keyof Mirror);
+      }
 
       // Mirrored, answered synchronously.
       if (prop in MIRRORED_DIRECT) {

--- a/src/reader-transport/protocol.ts
+++ b/src/reader-transport/protocol.ts
@@ -72,8 +72,19 @@ export interface Mirror {
   pdfTextQuality: unknown;
   pdfRenderedScale: number;
   pdfHasSpeakableText: boolean;
-  /** Needed by `handleNavKey`, which must decide locally. */
+  /**
+   * The engine's public GETTERS. They are read as properties, not called, so the proxy cannot answer
+   * them with a forwarding function — it did, and `ctrl.isFixedLayout` came back as a function that
+   * JSON.stringify turned into undefined. Every one of them is mirrored.
+   */
   isFixedLayout: boolean;
+  isScrolled: boolean;
+  readingScrollTop: number;
+  pdfPageCount: number;
+  furthestPosition: string | null;
+  dir: string | undefined;
+  title: string | undefined;
+  author: string | undefined;
   toc: unknown[];
   /** `tocHrefSectionMap()` with its default argument, as entries — a Map does not survive cloning. */
   tocHrefSection: [string, number][];

--- a/src/reader-transport/surface.ts
+++ b/src/reader-transport/surface.ts
@@ -24,7 +24,12 @@ export type Crossing =
   /** The host registers a callback and expects a SYNCHRONOUS answer. A port cannot answer in time. */
   | "sync-callback"
   /** Signature carries a live DOM object. It cannot be cloned, so it does not cross. */
-  | "dom-bound";
+  | "dom-bound"
+  /**
+   * Takes callbacks and an AbortSignal to report progress WHILE it runs. Neither can be cloned, so
+   * the call crosses without them and the host pushes progress back as events.
+   */
+  | "progressive";
 
 /**
  * The classification, one entry per public member of `FoliateController`.
@@ -77,6 +82,15 @@ export const CROSSING: Readonly<Record<string, Crossing>> = Object.freeze({
   // the consequence. Neither is re-implemented anywhere.
   onArrow: "sync-callback",
   onSpace: "sync-callback",
+
+  // ---- reports progress while it runs -----------------------------------------------------------
+  // `searchBook(query, { signal, onProgress, onBatch })` carries two functions and an AbortSignal
+  // inside an options object. It was invisible to the guard twice over — its signature spans several
+  // lines, and the callbacks are nested rather than named `cb` — so it would have reached the hosted
+  // transport and thrown DataCloneError the first time anyone searched. The query crosses alone; the
+  // host runs the search with its own callbacks and pushes each batch back, so results still arrive
+  // progressively rather than all at the end.
+  searchBook: "progressive",
 
   // ---- carries a live DOM object ----------------------------------------------------------------
   // `open` takes the container to render into. Hosted, the host supplies its own and the parameter

--- a/src/reader-transport/surface.ts
+++ b/src/reader-transport/surface.ts
@@ -55,6 +55,20 @@ export const CROSSING: Readonly<Record<string, Crossing>> = Object.freeze({
   pdfRenderedScale: "mirrored",
   pdfHasSpeakableText: "mirrored",
 
+  // ---- getters: read as properties, so only the mirror can answer them ---------------------------
+  // A getter is never called, so a forwarding function is not a slow answer — it is the wrong VALUE.
+  // MEASURED on WebKitGTK before these were classified: `ctrl.isFixedLayout` came back as a function,
+  // every consumer saw something truthy, and the PDF path reported `undefined`. They were invisible
+  // to the guard as well, because `get name()` does not look like `name(`.
+  isFixedLayout: "mirrored",
+  isScrolled: "mirrored",
+  readingScrollTop: "mirrored",
+  pdfPageCount: "mirrored",
+  furthestPosition: "mirrored",
+  dir: "mirrored",
+  title: "mirrored",
+  author: "mirrored",
+
   // ---- decided in the application ---------------------------------------------------------------
   // `handleNavKey` is called from a keydown listener and its answer drives `preventDefault()`, so it
   // cannot wait for a round trip. It does not need to: its decision is `navIntent(key)` — a pure

--- a/tests/unit/readerSurface.test.ts
+++ b/tests/unit/readerSurface.test.ts
@@ -30,11 +30,18 @@ function publicMethods(source: string): string[] {
   // the same indentation inside module-level functions — `walk(raw, level);` and
   // `collectLeadingBlocks(body, MAX, blocks);` were both reported as unclassified engine members.
   // A declaration opens a body on the same line here; a call ends in a semicolon.
-  // Ending in `{` is the whole discriminator, and it must NOT also forbid semicolons: four real
-  // members were lost that way, because an inline object type puts one inside the signature —
-  // `getChapterUnits(...): Promise<{ text: string; range: Range | null }[]> {`. A call statement
-  // ends in `;`, so requiring `{` already excludes it.
-  const re = /^ {2}(?:async\s+)?([a-zA-Z][A-Za-z0-9_]*)\s*(?:<[^>]*>)?\(.*\{\s*$/gm;
+  // A declaration is a name at member indentation followed by `(`, on a line that does NOT end in a
+  // semicolon. Two earlier attempts were both wrong in ways that hid real members:
+  //
+  //   • forbidding semicolons anywhere lost four members whose signature contains an inline object
+  //     type — `getChapterUnits(...): Promise<{ text: string; range: Range | null }[]>`;
+  //   • requiring the line to END in `{` lost every MULTI-LINE signature, and `searchBook` is one.
+  //     That is the worst kind of miss: the member was invisible, so no classification check could
+  //     ever fire on it, and it went to the hosted transport carrying two callbacks and an
+  //     AbortSignal that a MessagePort cannot clone.
+  //
+  // Ending in `;` is what a call statement does (`walk(raw, level);`), and a declaration never does.
+  const re = /^ {2}(?:async\s+)?([a-zA-Z][A-Za-z0-9_]*)\s*(?:<[^>]*>)?\((?!.*\);\s*$).*$/gm;
   for (const m of source.matchAll(re)) {
     const name = m[1];
     // Control-flow keywords indent the same way a member does; they are not members.
@@ -42,6 +49,29 @@ function publicMethods(source: string): string[] {
     names.add(name);
   }
   return [...names].sort();
+}
+
+/**
+ * A member's full signature: from its name to the brace that opens its body.
+ *
+ * Scanned with balanced parentheses rather than matched with a regex, because three regex attempts
+ * each truncated it somewhere that mattered — at the first `)`, which falls inside
+ * `(frac: number) => void`; at the first `{`, which falls inside `opts: { … }`; and a fixed-size
+ * window, which over-read into the body and made every void method look suspicious. Each of those
+ * hid or invented a problem. Counting brackets is the only version that describes the signature.
+ */
+function signatureOf(source: string, name: string): string {
+  const at = source.search(new RegExp(`^ {2}(?:async\\s+)?${name}\\s*(?:<[^>]*>)?\\(`, "m"));
+  if (at < 0) return "";
+  const open = source.indexOf("(", at);
+  let depth = 0;
+  let i = open;
+  for (; i < source.length; i++) {
+    if (source[i] === "(") depth++;
+    else if (source[i] === ")" && --depth === 0) break;
+  }
+  const brace = source.indexOf("{", i);
+  return source.slice(at, brace < 0 ? i + 1 : brace + 1);
 }
 
 describe("reader engine surface", () => {
@@ -66,11 +96,18 @@ describe("reader engine surface", () => {
     // forwarded: a non-promise return, a DOM type, or a callback parameter.
     const unclassified = methods.filter((name) => !(name in CROSSING));
     const suspicious = unclassified.filter((name) => {
-      const sig = source.match(new RegExp(`^ {2}(?:async\\s+)?${name}\\s*(?:<[^>]*>)?\\([^)]*\\)[^{]*`, "m"))?.[0] ?? "";
+      const sig = signatureOf(source, name);
       const returnsPromise = /:\s*Promise</.test(sig);
       const isAsync = /^\s{2}async\s/.test(sig);
-      const returnsVoid = /:\s*void\s*$/.test(sig.trim());
-      const takesCallback = /\bcb\s*:/.test(sig);
+      // `sig` now ends at the opening brace, so the void test has to allow for it. Without this the
+      // guard flagged every plain `foo(): void {` member in the class.
+      const returnsVoid = /:\s*void\s*\{?\s*$/.test(sig.trim());
+      // A callback is not always named `cb`. `searchBook(query, { signal, onProgress, onBatch })`
+      // hides two functions and an AbortSignal inside an options object, and matching only `cb:`
+      // declared it plainly forwardable — it would have thrown DataCloneError the first time search
+      // ran on the hosted path. Any function TYPE in the signature counts, however it is spelled,
+      // and so does an AbortSignal, which is just as uncloneable and just as easy to miss.
+      const takesCallback = /\bcb\s*:/.test(sig) || /=>/.test(sig) || /\bAbortSignal\b/.test(sig);
       const touchesDom = /\b(Range|HTMLElement|Document|Node|Element|Selection)\b/.test(sig);
       return takesCallback || touchesDom || !(returnsPromise || isAsync || returnsVoid);
     });

--- a/tests/unit/readerSurface.test.ts
+++ b/tests/unit/readerSurface.test.ts
@@ -48,6 +48,15 @@ function publicMethods(source: string): string[] {
     if (["if", "for", "while", "switch", "catch", "return", "constructor"].includes(name)) continue;
     names.add(name);
   }
+  // GETTERS TOO, and they were the third blind spot.
+  //
+  // `get isFixedLayout(): boolean {` never matched the pattern above, so eight public members were
+  // invisible — and the transport answered every one of them with a forwarding FUNCTION instead of a
+  // value. MEASURED on WebKitGTK: `ctrl.isFixedLayout` came back as a function, and the PDF path
+  // reported `undefined`. A getter is read, never called, so it can only ever be served from the
+  // mirror; it must be classified.
+  for (const m of source.matchAll(/^ {2}get\s+([a-zA-Z][A-Za-z0-9_]*)\s*\(/gm)) names.add(m[1]);
+
   return [...names].sort();
 }
 


### PR DESCRIPTION
Closes the runtime gaps left open by the wiring stage. **23 PASS · 0 FAIL · 0 UNKNOWN** on real WebKitGTK.

## Two real transport defects, both found at runtime

**`searchBook` could not cross at all.** It takes two callbacks and an `AbortSignal` inside an options object — none cloneable — and `Reader.tsx:1489` calls it exactly that way. It would have thrown `DataCloneError` the first time anyone searched. The callbacks now stay app-side; only the query crosses, and the host pushes each batch back so hits still arrive **progressively** (measured: 960 hits, 3 batches, 3 progress callbacks).

**Eight getters were answered with functions.** `isFixedLayout`, `pdfPageCount`, `dir`, `title`, `author`, `isScrolled`, `readingScrollTop`, `furthestPosition` are read as properties, so a forwarding function is not a slow answer — it is the wrong value. A function is truthy, so `if (ctrl.isFixedLayout)` took the fixed-layout branch on every book. Measured: the PDF pass reported `fixedLayout: undefined`. All eight now travel in the mirror.

## Three blind spots closed in the surface guard

Each was found by a runtime failure, not by reading code:

1. **Multi-line signatures** were invisible — the extractor required the declaration to end in `{`. `searchBook` is multi-line, so no check could ever fire on it.
2. **Callbacks nested in an options object** were missed — the shape test looked for a parameter named `cb`. Now any function type or `AbortSignal` counts.
3. **Getters** were invisible — `get name()` doesn't look like `name(`.

Signatures are now read by **counting brackets**. Matching to the first `)` cuts inside `(frac: number) => void`; to the first `{` cuts inside `opts: {`; a fixed window over-reads into the body and flagged 25 false positives. Each of those either hid a real problem or invented many.

## Runtime evidence

| Feature | Evidence |
|---|---|
| Space keypress | real `xdotool key space` → **app callback asked 2×** |
| Highlights | add / load / setColor / remove — all 4 |
| References (notes) | `setReferences` |
| Search | **960 hits, 3 batches, 3 progress** |
| TTS tracking | **121 units**, spotlight shown and cleared |
| PDF | real `%PDF-` file → `fixedLayout=true`, **2 pages**, text quality crossed |
| User font over `asset:` | **LOADED** |
| Real X11 input | 6 pointer events into the section |
| Boundary | Tauri internals / app doc / secrets `SecurityError`; book path & traversal 404; cross-origin refused; **no MessagePort on the global** |

## Windows

`preseam-scrolled` **byte-identical** · `preseam-paged` **byte-identical** · interaction gate clean · all 9 lifecycle guarantees · `dist/reader-host` **absent** · 312/11 unit tests · all three production gates pass.

`public/foliate-js/` and `src/reader-engine/`: **zero diff**.