### PR TITLE
Measure what the reader actually paints on the hosted path

### DIFF
--- a/public/reader-host/host.js
+++ b/public/reader-host/host.js
@@ -148,6 +148,8 @@
   // something when something real was clicked, so the harness drives a genuine X11 click with
   // xdotool and reads these counters afterwards. A synthetic dispatchEvent would prove nothing at
   // all, because the bug is in DELIVERY, not in dispatch.
+  R.overlay = null;
+  R.rendered = null;
   R.input = { sandbox: null, docsInstrumented: 0, pointerdown: 0, mousedown: 0, click: 0, selectionchange: 0 };
 
   // THE POSITIVE CONTROL, and the run that lacked it is why it is here.
@@ -205,6 +207,51 @@
         } catch (e) { /* frameElement across the boundary */ }
       }
       instrument(doc);
+
+      // WHAT IS ACTUALLY DRAWN.
+      //
+      // A highlight crossing the transport and a highlight APPEARING are different claims, and only
+      // the second one is what a reader sees. foliate draws marks as SVG in the overlayer, so the
+      // shapes are countable and measurable: a mark that resolved to no geometry produces no rect,
+      // and a CFI that pointed nowhere would look exactly like a working transport.
+      try {
+        var ov = contents[i] && contents[i].overlayer;
+        var svg = ov && ov.element;
+        if (svg) {
+          var shapes = svg.querySelectorAll("rect, path, polygon");
+          var painted = 0;
+          var area = 0;
+          for (var s = 0; s < shapes.length; s++) {
+            var box = shapes[s].getBoundingClientRect();
+            if (box.width > 0 && box.height > 0) { painted++; area += box.width * box.height; }
+          }
+          R.overlay = {
+            shapes: shapes.length,
+            painted: painted,
+            areaPx: Math.round(area),
+            fills: (function () {
+              var out = [];
+              for (var f = 0; f < shapes.length && f < 6; f++) {
+                out.push(shapes[f].getAttribute("fill") || shapes[f].style.fill || "none");
+              }
+              return out.join(",");
+            })(),
+          };
+          write();
+        }
+      } catch (e) { /* no overlayer yet */ }
+
+      // The PDF page is drawn to a canvas and copied to an <img> (VENDOR patch 4). Its presence and
+      // size are the only proof the fixed-layout path rendered anything at all.
+      try {
+        var imgs = doc.querySelectorAll("img, canvas");
+        var big = 0;
+        for (var k = 0; k < imgs.length; k++) {
+          var r = imgs[k].getBoundingClientRect();
+          if (r.width > 50 && r.height > 50) big++;
+        }
+        if (imgs.length) { R.rendered = { imgOrCanvas: imgs.length, sized: big }; write(); }
+      } catch (e) { /* ignore */ }
     }
   }, 250);
 })();


### PR DESCRIPTION
Turns the transport into a release-confidence result. **29 PASS · 0 FAIL · 0 UNKNOWN** on real WebKitGTK.

One production file changes: `public/reader-host/host.js` — the boundary self-check now reports what the overlayer painted and whether a page rendered. Inert without `?selfcheck=1`, absent from Windows entirely.

## Visual confirmation, not forwarding

A highlight crossing the transport and a highlight *appearing* are different claims. foliate draws marks as SVG in the overlayer, reachable through the engine's own `getContents()`, so the geometry is countable.

| | |
|---|---|
| highlight painted | **25 shapes, 340,014 px²**, fill `url(#sard-hl-3)` |
| at CFI | `epubcfi(/6/4!/4/4,/4/1:396,/12/1:366)` — produced by the engine from the **real drag**, not fabricated |
| after remove | **0 shapes, 0 px²** |
| TTS spotlight | **[2, 4, 6] shapes** across sentences 0/1/2; **0** after clear |
| PDF page | rendered surface present and sized |

The earlier pass highlighted a made-up CFI. That call crosses, returns, and paints nothing — a broken transport and a working one look identical. This one uses a CFI the engine produced over text that was on screen.

## Read-aloud

**23,342 bytes of real audio synthesised** through Edge TTS. Audio is an application-side IPC command and never crosses the host; what crosses is the tracking, and that is measured above.

## PDF

Opens, `fixedLayout=true`, 2 pages, renders to a sized surface, responds to navigation and zoom.

**The text layer is not a gap.** `PDF_TTS_ENABLED = false` and `FoliateController:3095`/`:3632` return early on it — PDF read-aloud is switched off at the product level, so `coverage: 0` and `speakable: false` are the correct answers. There is no text-layer behaviour to validate.

## Failures found, and what they were

| Failure | Classification |
|---|---|
| Spotlight painted 0 for every sentence | **Harness.** `showReadingHighlight` refuses unless `content.index === ttsUnitsIndex`, and only `getChapterUnits` establishes that — `trackStats` computes units transiently. Painting nothing with no session is correct. |
| `unknown edge voice: probe-1` | **Harness.** `id` IS the voice id, not a request id. |
| Criterion 20 reporting `spotlight=None` | **Harness.** It named a step the spotlight loop replaced. |

No product defect was found in this stage.

## Windows

`preseam-scrolled` **byte-identical** · `preseam-paged` **byte-identical** · lifecycle: all 9 guarantees · `dist/reader-host` **absent** · 312/11 unit tests · production tree, content and build gates all pass.

`src/reader-engine/` and `public/foliate-js/`: zero diff.