### PR TITLE
The reader host must live inside the reading area, not over the window

### DIFF
--- a/src/reader-transport/hosted.ts
+++ b/src/reader-transport/hosted.ts
@@ -75,16 +75,34 @@ export class HostedReader {
   // Deliberately NOT `#private`. The proxy below has to read `handlers` and dispatch on the members
   // declared here, and a `#name` field is unreachable from outside the class body — an earlier draft
   // reached for one through a cast, which type-checks and is always `undefined` at run time.
-  private readonly port: MessagePort;
+  // No port until the first `open()` gives the host somewhere to live. Everything before that reads
+  // the empty mirror, which is the same thing the direct path shows before a book is opened.
+  private port: MessagePort | null = null;
+  private frame: HTMLIFrameElement | null = null;
+  private mounting: Promise<void> | null = null;
   private nextId = 1;
   private readonly pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
   private mirror: Mirror = EMPTY_MIRROR;
   readonly handlers = new Map<string, (...args: unknown[]) => unknown>();
 
-  constructor(port: MessagePort) {
-    this.port = port;
-    port.onmessage = (e: MessageEvent<Reply | Push>) => this.receive(e.data);
-    port.start();
+  /**
+   * Create the host inside the reading area, once.
+   *
+   * Deferred to the first `open()` because an iframe cannot be re-parented without reloading — see
+   * `mountHostIn`. Concurrent opens share one mount rather than racing two hosts into the DOM.
+   */
+  private ensureHost(container: HTMLElement): Promise<void> {
+    if (this.port && this.frame?.isConnected) return Promise.resolve();
+    if (this.mounting) return this.mounting;
+    this.mounting = (async () => {
+      const { mountHostIn } = await import("./index");
+      const { port, frame } = await mountHostIn(container);
+      this.port = port;
+      this.frame = frame;
+      port.onmessage = (e: MessageEvent<Reply | Push>) => this.receive(e.data);
+      port.start();
+    })();
+    return this.mounting;
   }
 
   private receive(msg: Reply | Push): void {
@@ -101,10 +119,16 @@ export class HostedReader {
   }
 
   private send(req: RequestBody, transfer: Transferable[] = []): Promise<unknown> {
+    const port = this.port;
+    if (!port) {
+      // Named, not silent. Before the first `open()` there is no host, and a call arriving here is a
+      // caller doing something the direct path would also find meaningless on a reader with no book.
+      return Promise.reject(new Error(`the reader host is not mounted yet (${JSON.stringify(req).slice(0, 60)})`));
+    }
     const id = this.nextId++;
     return new Promise((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
-      this.port.postMessage({ ...req, id } as Request, transfer);
+      port.postMessage({ ...req, id } as Request, transfer);
     });
   }
 
@@ -128,7 +152,10 @@ export class HostedReader {
    * the bytes are read HERE and transferred, which is also the cheaper of the two measured options
    * (1257 ms vs 1278 ms on a 14.1 MB EPUB). `container` is ignored: the host owns its own.
    */
-  async open(source: string, _container: HTMLElement, opts: unknown): Promise<void> {
+  async open(source: string, container: HTMLElement, opts: unknown): Promise<void> {
+    // The container is USED, not ignored. Ignoring it is what produced a full-window overlay that
+    // hid the toolbar and showed a blank page on a real Linux machine.
+    await this.ensureHost(container);
     const bytes = await (await fetch(source)).arrayBuffer();
     await this.send({ kind: "open", bytes, opts }, [bytes]);
   }
@@ -262,8 +289,8 @@ export class HostedReader {
  * and writing them out by hand invites the one that is subtly different from the rest — which is the
  * failure mode this whole seam is trying to avoid.
  */
-export function hostedReader(port: MessagePort): FoliateController {
-  const impl = new HostedReader(port);
+export function hostedReader(): FoliateController {
+  const impl = new HostedReader();
   return new Proxy(impl, {
     get(target, prop, receiver) {
       if (typeof prop !== "string") return Reflect.get(target, prop, receiver);

--- a/src/reader-transport/index.ts
+++ b/src/reader-transport/index.ts
@@ -27,15 +27,27 @@ export function needsReaderHost(ua: string = navigator.userAgent): boolean {
   return /AppleWebKit/.test(ua) && !/Chrome|Chromium|Edg\//.test(ua);
 }
 
-/** The host document, mounted once and kept for the life of the window. */
-let hostFrame: HTMLIFrameElement | null = null;
-
-function mountHost(): Promise<MessagePort> {
+/**
+ * Create the host inside the container the reader gave us, and complete the handshake.
+ *
+ * WHY THE CONTAINER, AND WHY SO LATE. The first version of this appended the frame to
+ * `document.body` at `position:absolute; inset:0`, intending the reading area to move it into place
+ * later. Nothing ever did — the accessor written for that was never called — so on a real Linux
+ * machine the host became a full-window overlay: it covered the toolbar, which vanished, and showed
+ * its own empty background, which read as a blank page. The reader was working the whole time,
+ * behind it.
+ *
+ * Moving the frame afterwards is not an option and that is the reason this is deferred rather than
+ * fixed in place: re-parenting an iframe reloads its document, which would destroy the host and the
+ * port with it. So the frame is created where it belongs, once, at the moment the reader first has a
+ * container to give — which is `open()`.
+ */
+export function mountHostIn(container: HTMLElement): Promise<{ port: MessagePort; frame: HTMLIFrameElement }> {
   return new Promise((resolve, reject) => {
     const frame = document.createElement("iframe");
-    hostFrame = frame;
     frame.setAttribute("title", "reader");
-    frame.style.cssText = "position:absolute;inset:0;width:100%;height:100%;border:0";
+    // Fills the reading area it was given, and nothing beyond it.
+    frame.style.cssText = "display:block;width:100%;height:100%;border:0;background:transparent";
 
     const onMessage = (e: MessageEvent) => {
       if (e.source !== frame.contentWindow) return; // `e.origin` cannot authenticate; `e.source` can
@@ -43,28 +55,27 @@ function mountHost(): Promise<MessagePort> {
       removeEventListener("message", onMessage);
       const channel = new MessageChannel();
       frame.contentWindow?.postMessage({ __sardHostInit: true }, "*", [channel.port2]);
-      resolve(channel.port1);
+      resolve({ port: channel.port1, frame });
     };
     addEventListener("message", onMessage);
     frame.addEventListener("error", () => reject(new Error("the reader host failed to load")));
-    frame.src = "sardhost://localhost/";
-    document.body.appendChild(frame);
+
+    // PROBE-ONLY hook on the throwaway branch; nothing sets this in a shipped build.
+    const probe = (globalThis as { __sardHostSelfcheck?: boolean }).__sardHostSelfcheck;
+    frame.src = probe ? "sardhost://localhost/?selfcheck=1" : "sardhost://localhost/";
+    // In the container BEFORE it loads. See above: it can never be moved afterwards.
+    container.replaceChildren(frame);
   });
 }
 
 /**
  * The reader for this platform.
  *
- * Windows resolves immediately with the object it has always used. The hosted path has to wait for
- * the host document to announce itself, which is why this is asynchronous on both — a signature that
- * differs by platform would push the difference into the caller.
+ * Windows resolves immediately with the object it has always used. The hosted reader is returned
+ * immediately too — it has no host yet, and creates one the first time `open()` gives it somewhere
+ * to put it.
  */
 export async function createReader(): Promise<FoliateController> {
   if (!needsReaderHost()) return new FoliateController();
-  return hostedReader(await mountHost());
-}
-
-/** The frame the host runs in, for the reading area to place. Null on the direct path. */
-export function readerHostFrame(): HTMLIFrameElement | null {
-  return hostFrame;
+  return hostedReader();
 }


### PR DESCRIPTION
Fixes the blank reader reported from a real Linux machine: the toolbar appears, then disappears, and the reading area is blank.

## Root cause — separate from the fix

`mountHost()` appended the host iframe to `document.body` with `position:absolute; inset:0; width:100%; height:100%`, intending the reading area to move it into place afterwards. **Nothing ever did.** `readerHostFrame()`, the accessor written for exactly that, was never called by anything.

So the host became a full-window overlay. It covered the toolbar — which is why the toolbar "disappears" — and showed its own empty background, `#f7f2e8`, which is the blank page. **The reader was working the whole time, behind it.** The book had loaded; nobody could see it.

This is a composition defect in the transport. It is not the transport architecture, and it is not the engine.

## Why 29 runtime criteria passed over it

The probe page gave the reader a stage that filled the entire window and put nothing else on the page. A host frame covering the whole window was indistinguishable from one placed correctly, and the probe measured the engine **through the transport API** rather than looking at what was on screen. The gate validated the transport and never the composition.

## Reproduced, then fixed — same run, measured

| | before | after |
|---|---|---|
| frame parent | `body` | **`stage`** |
| frame rect | top 0, height 900 (full window) | **top 48, height 852** |
| topmost element at the toolbar's centre | **`IFRAME`** | **`toolbar`** |
| overlaps toolbar | true | **false** |
| gate | 30 PASS · **2 FAIL** | **32 PASS · 0 FAIL** |

The probe page now has a toolbar above the reading area, like the real reader, so "did the host stay inside the area it was given" is a question the gate can ask at all.

## Why the fix defers the mount rather than moving the frame

**Re-parenting an iframe reloads its document**, which would destroy the host and the port with it. So the frame cannot be created early and moved later. It is now created inside the container the reader passes to `open()` — the first moment a container exists — and never moved.

`open(source, container, opts)` uses its `container` argument, which it previously ignored.

## A second gap this closed

Every earlier probe run opened `/__probe/book.epub`, a **same-origin** path. The application opens `convertFileSrc(filePath)` — an `asset:` URL — so the fetch that actually happens in the product had never been exercised. The gate now stages a real book into app data and opens it through that URL: `asset://localhost/...` → **opens**.

## Verification

| | |
|---|---|
| Windows `preseam-scrolled` | **byte-identical** |
| Windows `preseam-paged` | **byte-identical** |
| Windows interaction gate | no problem detected |
| Windows lifecycle | all 9 guarantees |
| Unit suite | 312 / 11 skipped |
| production tree / content / build | pass |
| Windows `dist/reader-host` | absent |
| `src/reader-engine/`, `public/foliate-js/` | **zero diff** |

Two files, +65/−27. No engine change, no Foliate fork, no Linux-only reader, no Windows change.