### PR TITLE
Gate the desktop-only plugins so a mobile target can compile

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,19 +36,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
-# The OFFICIAL in-app updater: fetches a signed manifest from GitHub Releases, verifies the
-# minisign signature against the public key in tauri.conf.json, then runs the NSIS installer with
-# `/UPDATE`. It replaces the hand-rolled check-only path this project carried before — one update
-# system, not two. Sard is desktop-only, so this needs no per-platform cfg guard.
-tauri-plugin-updater = "2"
-# `relaunch()` after an install. On Windows the NSIS installer restarts Sard itself (the plugin
-# passes `/ARGS`), so this is belt-and-braces there — but it is the documented path on macOS and
-# Linux, and having it means the frontend has one restart call that is correct everywhere.
-tauri-plugin-process = "2"
 tauri-plugin-dialog = "2"
-# RAWY-173 (AUD-9): a second launch focuses the existing window instead of starting a rival instance
-# that would attach the same WAL DB + fight over per-session state.
-tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # RAWY-178 (AUD-12): `functions` enables `create_scalar_function` for the `afold` Arabic search fold
@@ -75,6 +63,40 @@ msedge-tts = "0.4"
 # rustls, so `ClientConfig::builder()`'s auto-detection is ambiguous and PANICS (hanging the Edge WS
 # connect). We install aws-lc-rs as the explicit process default at startup to disambiguate.
 rustls = { version = "0.23", features = ["aws_lc_rs"] }
+
+# DESKTOP-ONLY PLUGINS. All three are unavailable on Android and iOS, and one of them does not merely
+# fail at run time — it fails to COMPILE:
+#
+#   single-instance   `src/lib.rs` opens with `#![cfg(not(any(target_os = "android", target_os =
+#                     "ios")))]`, a CRATE-level attribute. On mobile the crate compiles to nothing, so
+#                     `tauri_plugin_single_instance::init` does not exist and the call site is an
+#                     unresolved path. This is the hard blocker.
+#   updater           Compiles on mobile but declares `platforms.support.{android,ios}.level =
+#   process           "none"`, and both stores forbid an application updating itself outside the
+#                     store. The plugin's own README states the rule this section follows: "you can
+#                     add the dependencies on the `[dependencies]` section if you do not target
+#                     mobile". `process` travels with it because it exists to serve the updater flow.
+#
+# WHY A `target` SECTION AND NOT `cfg(desktop)`. Tauri's `desktop`/`mobile` aliases are emitted by
+# tauri-build at COMPILE time (tauri-build/src/lib.rs), so Cargo — which resolves dependencies before
+# any build script runs — cannot see them. Dependency gating has to use a built-in cfg; the call
+# sites in `lib.rs` use `cfg(desktop)`, which is the same set expressed where the alias does exist.
+#
+# Desktop resolution is unchanged: on Windows, macOS and Linux this predicate is true, so the three
+# crates are still ordinary dependencies and `Cargo.lock` does not move.
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+# RAWY-173 (AUD-9): a second launch focuses the existing window instead of starting a rival instance
+# that would attach the same WAL DB + fight over per-session state.
+tauri-plugin-single-instance = "2"
+# The OFFICIAL in-app updater: fetches a signed manifest from GitHub Releases, verifies the
+# minisign signature against the public key in tauri.conf.json, then runs the NSIS installer with
+# `/UPDATE`. It replaces the hand-rolled check-only path this project carried before — one update
+# system, not two.
+tauri-plugin-updater = "2"
+# `relaunch()` after an install. On Windows the NSIS installer restarts Sard itself (the plugin
+# passes `/ARGS`), so this is belt-and-braces there — but it is the documented path on macOS and
+# Linux, and having it means the frontend has one restart call that is correct everywhere.
+tauri-plugin-process = "2"
 
 # RAWY-196: reach WebView2's own settings to strip the browser chrome (find bar, reload, print,
 # context menu). Tauri exposes none of these, so they are set through `with_webview` -> the WebView2

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main window",
+  "description": "Capability for the main window on desktop",
+  "platforms": ["linux", "macOS", "windows"],
   "windows": ["main"],
   "permissions": [
     "core:default",

--- a/src-tauri/capabilities/mobile.json
+++ b/src-tauri/capabilities/mobile.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "mobile",
+  "description": "Capability for the main window on Android and iOS",
+  "platforms": ["android", "iOS"],
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "opener:default",
+    "dialog:default"
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -174,19 +174,39 @@ pub fn run() {
     println!("[Sard] {BUILD_KIND_BANNER}");
 
     let builder = tauri::Builder::default()
-        // RAWY-173 (AUD-9): registered FIRST so a SECOND launch is intercepted before it opens a window
-        // or attaches the same WAL DB. The callback runs in the ALREADY-RUNNING instance — focus its
-        // window instead of starting a rival that would fight over the DB + per-session state. (A file
-        // arg could be routed here later; for now, just surface the existing window.)
-        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
-            if let Some(w) = app.get_webview_window("main") {
-                let _ = w.unminimize();
-                let _ = w.show();
-                let _ = w.set_focus();
-            }
-        }))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init());
+
+    // SINGLE INSTANCE — DESKTOP ONLY, and not by preference.
+    //
+    // RAWY-173 (AUD-9): registered FIRST so a SECOND launch is intercepted before it opens a window
+    // or attaches the same WAL DB. The callback runs in the ALREADY-RUNNING instance — focus its
+    // window instead of starting a rival that would fight over the DB + per-session state. (A file
+    // arg could be routed here later; for now, just surface the existing window.)
+    //
+    // WHY IT MOVED OUT OF THE CHAIN ABOVE. `tauri-plugin-single-instance` opens with a CRATE-level
+    // `#![cfg(not(any(target_os = "android", target_os = "ios")))]`, so on mobile the crate compiles
+    // to nothing and this path does not resolve. Left in the chain it is not a plugin that misbehaves
+    // on a phone — it is a build that cannot start.
+    //
+    // The concept does not transfer either: an Android activity and an iOS app are single-instance by
+    // the platform's own lifecycle, so there is no rival process for this to intercept. A file handed
+    // in from another app arrives through an intent or a document URL, not a second argv.
+    //
+    // `cfg(desktop)` rather than `cfg(not(any(target_os = ...)))` because that alias is exactly what
+    // it means, tauri-build declares it (so no `unexpected_cfgs` warning), and this file already uses
+    // its counterpart at `#[cfg_attr(mobile, tauri::mobile_entry_point)]`.
+    //
+    // ORDERING NOTE: it is no longer literally first in the chain, but it is still registered before
+    // the window is created and before `setup()` opens the database, which is what RAWY-173 required.
+    #[cfg(desktop)]
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+        if let Some(w) = app.get_webview_window("main") {
+            let _ = w.unminimize();
+            let _ = w.show();
+            let _ = w.set_focus();
+        }
+    }));
 
     // THE READER-HOST ORIGIN (origin-isolation step 1) — NOT ON WINDOWS, DELIBERATELY.
     //
@@ -215,7 +235,15 @@ pub fn run() {
     // the binary has no update path at all — not a disabled one, none.
     //
     // `process` (relaunch-after-install) goes with it: it exists to serve the updater flow.
-    #[cfg(not(feature = "diag"))]
+    //
+    // AND DESKTOP ONLY, which is a second and independent reason. Unlike single-instance these two
+    // crates do compile for mobile, so nothing would fail loudly — they simply declare
+    // `platforms.support.{android,ios}.level = "none"` and do nothing, which is the worse failure:
+    // an update path that silently never updates. Both stores also forbid an application updating
+    // itself outside the store, so on mobile this is not a missing feature but a prohibited one.
+    // A mobile binary therefore has no update path at all — not a disabled one, none — exactly as a
+    // diagnostic build does, and for the same reason: the safest update mechanism is an absent one.
+    #[cfg(all(desktop, not(feature = "diag")))]
     let builder = builder
         // Everything the updater needs — the manifest endpoint, the minisign public key and the
         // Windows install mode — is declarative, in tauri.conf.json; there is no update command of

--- a/tests/unit/capabilityPlatforms.test.ts
+++ b/tests/unit/capabilityPlatforms.test.ts
@@ -1,0 +1,100 @@
+// CAPABILITIES MUST NOT GRANT A PERMISSION ITS PLATFORM HAS NO PLUGIN FOR.
+//
+// `updater` and `process` are registered under `#[cfg(all(desktop, not(feature = "diag")))]`, and
+// `single-instance` cannot even compile for mobile. A capability that still lists `updater:default`
+// on Android or iOS is asking the ACL for a permission no registered plugin provides — a mobile-only
+// failure that no desktop build, and no desktop test, can reach.
+//
+// So the invariant is asserted here, over the capability files themselves, where it is cheap and
+// platform-independent. These files are data: nothing else in the suite reads them, and a hand edit
+// that re-granted a desktop permission to mobile would otherwise be found by a device, months later.
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const DIR = join(__dirname, "..", "..", "src-tauri", "capabilities");
+
+interface Capability {
+  identifier: string;
+  platforms?: string[];
+  windows?: string[];
+  permissions: string[];
+}
+
+const files = readdirSync(DIR).filter((f) => f.endsWith(".json"));
+const load = (f: string): Capability => JSON.parse(readFileSync(join(DIR, f), "utf8"));
+const caps = files.map((f) => ({ file: f, cap: load(f) }));
+
+const DESKTOP = ["linux", "macOS", "windows"] as const;
+const MOBILE = ["android", "iOS"] as const;
+
+/** Permission prefixes whose plugin is registered only on desktop — see src-tauri/src/lib.rs. */
+const DESKTOP_ONLY_PREFIXES = ["updater:", "process:"];
+
+describe("capabilities — every platform is covered exactly once", () => {
+  it("declares platforms explicitly on every capability", () => {
+    // An omitted `platforms` means "all targets" — which is precisely the bug this guards against,
+    // because it silently re-grants desktop permissions to mobile.
+    for (const { file, cap } of caps) {
+      expect(Array.isArray(cap.platforms), `${file} must declare platforms`).toBe(true);
+      expect(cap.platforms!.length, `${file} must not declare an empty platform list`).toBeGreaterThan(0);
+    }
+  });
+
+  it("covers all five targets with no gap and no overlap", () => {
+    const seen = new Map<string, string>();
+    for (const { file, cap } of caps) {
+      for (const p of cap.platforms!) {
+        expect(seen.has(p), `${p} is claimed by both ${seen.get(p)} and ${file}`).toBe(false);
+        seen.set(p, file);
+      }
+    }
+    expect([...seen.keys()].sort()).toEqual([...DESKTOP, ...MOBILE].sort());
+  });
+});
+
+describe("capabilities — mobile is not granted desktop-only permissions", () => {
+  const mobileCaps = caps.filter(({ cap }) => cap.platforms!.some((p) => (MOBILE as readonly string[]).includes(p)));
+
+  it("has at least one mobile capability, or this suite proves nothing", () => {
+    expect(mobileCaps.length).toBeGreaterThan(0);
+  });
+
+  it("grants no updater or process permission on any mobile target", () => {
+    for (const { file, cap } of mobileCaps) {
+      for (const perm of cap.permissions) {
+        for (const prefix of DESKTOP_ONLY_PREFIXES) {
+          expect(perm.startsWith(prefix), `${file} grants "${perm}", whose plugin is desktop-only`).toBe(false);
+        }
+      }
+    }
+  });
+});
+
+describe("capabilities — desktop is unchanged", () => {
+  const desktop = caps.find(({ cap }) => cap.identifier === "default")!;
+
+  it("still targets exactly the three desktop platforms", () => {
+    expect(desktop.cap.platforms!.slice().sort()).toEqual([...DESKTOP].slice().sort());
+  });
+
+  // The permission list is asserted VERBATIM, not by property. Desktop behaviour must be preserved
+  // exactly across this change, and an exact list is the only assertion that would notice a silent
+  // addition or removal.
+  it("keeps every permission it had before the split", () => {
+    expect(desktop.cap.permissions).toEqual([
+      "core:default",
+      "opener:default",
+      "dialog:default",
+      "updater:default",
+      "process:allow-restart",
+      "core:window:allow-set-fullscreen",
+      "core:window:allow-is-fullscreen",
+      "core:window:allow-destroy",
+    ]);
+  });
+
+  it("still scopes to the main window", () => {
+    expect(desktop.cap.windows).toEqual(["main"]);
+  });
+});


### PR DESCRIPTION
## What

Three plugins are unavailable on Android and iOS. One of them does not merely misbehave there — it
stops the build. This gates all three, and splits the capability file for the matching reason.

5 files, +188 / −25. No frontend change.

## Why

**`tauri-plugin-single-instance` is a hard blocker.** Its `src/lib.rs` opens with a **crate-level**
`#![cfg(not(any(target_os = "android", target_os = "ios")))]`. On mobile the crate compiles to
nothing, so `tauri_plugin_single_instance::init` does not exist and the unconditional call site is an
unresolved path.

**`updater` and `process` are the subtler problem.** They *do* compile for mobile, so nothing fails
loudly — they declare `platforms.support.{android,ios}.level = "none"` and quietly do nothing, which
is the worse failure: an update path that exists and never updates. Both stores also forbid an
application updating itself outside the store, so on mobile this is a prohibited feature rather than
a missing one. A mobile binary now has no update path at all — not a disabled one, none — exactly as
a diagnostic build has none, and for the same reason.

**The capability file granted `updater:default` and `process:allow-restart` unconditionally**, so on
mobile it would have asked the ACL for permissions no registered plugin provides.

## How

| File | Change |
|---|---|
| `src-tauri/Cargo.toml` | The three deps move to `[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]` |
| `src-tauri/src/lib.rs` | `#[cfg(desktop)]` on single-instance; updater/process widened to `#[cfg(all(desktop, not(feature = "diag")))]` |
| `src-tauri/capabilities/default.json` | Gains `"platforms": ["linux","macOS","windows"]`. Permission list **verbatim** |
| `src-tauri/capabilities/mobile.json` | **New.** `["android","iOS"]`, core/opener/dialog, neither desktop-only permission |
| `tests/unit/capabilityPlatforms.test.ts` | **New.** 7 tests |

A `target` section rather than `cfg(desktop)` in Cargo.toml because **Cargo resolves dependencies
before any build script runs**, so it cannot see Tauri's alias. This is the form the updater plugin's
own README prescribes. The call sites use `cfg(desktop)` — the same set, expressed where the alias
does exist, and already relied on in this file at `#[cfg_attr(mobile, tauri::mobile_entry_point)]`.

Ordering is preserved where it matters: single-instance still registers before the window exists and
before `setup()` opens the database, which is what RAWY-173 required.

## Desktop is unchanged

The predicate is true on Windows, macOS and Linux, so the three crates remain ordinary dependencies
and **`Cargo.lock` does not move** — which `--locked` proves. The new test asserts desktop's
permission list **verbatim**, so a silent addition or removal fails the build.

## Verification (local; CI is the independent check)

| Check | Result |
|---|---|
| `cargo check --all-targets --locked` | PASS, **zero warnings** — no `unexpected_cfgs`, confirming `desktop` is a declared alias |
| `cargo test --locked` | **111 passed, 0 failed**; this diff adds and removes **0** Rust tests |
| Product typecheck | PASS |
| Unit suite | **329 passed / 11 skipped** — baseline on `develop` is 322, so exactly **+7**, with no existing test altered |
| Production tree / content / build gates | PASS — 450 files (449 + `mobile.json`, which correctly ships as product configuration) |

## What this does NOT establish

**That a mobile target builds.** No NDK or Xcode toolchain is available here, so
`cargo check --target aarch64-linux-android` was not run. The claim is narrower: a known hard blocker
is removed and desktop is provably unchanged. The cross-compile is what will confirm it.

`src/lib/updater.ts` and `features/updater/` still import the updater/process JS plugins. That is
desktop chrome — mobile gets its own front end later — so changing it now would be out of scope. It
is a real follow-up, recorded rather than done.