### PR TITLE
Discord Rich Presence: show what you're reading, with an on/off switch

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -495,7 +495,7 @@ checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
 dependencies = [
  "byteorder",
  "fnv",
- "uuid",
+ "uuid 1.23.4",
 ]
 
 [[package]]
@@ -880,6 +880,21 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "discord-rich-presence"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c55d69cab17c19677ce3a5f8face993a9e6eaf847fecac3547f3a3ff4a2494"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "thiserror 2.0.18",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -2348,7 +2363,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tungstenite",
  "ureq",
- "uuid",
+ "uuid 1.23.4",
 ]
 
 [[package]]
@@ -3395,6 +3410,7 @@ dependencies = [
 name = "sard"
 version = "1.2.2"
 dependencies = [
+ "discord-rich-presence",
  "image",
  "msedge-tts",
  "quick-xml 0.36.2",
@@ -3438,7 +3454,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "uuid",
+ "uuid 1.23.4",
 ]
 
 [[package]]
@@ -4111,7 +4127,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "url",
- "uuid",
+ "uuid 1.23.4",
  "walkdir",
 ]
 
@@ -4352,7 +4368,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
- "uuid",
+ "uuid 1.23.4",
  "walkdir",
 ]
 
@@ -4921,6 +4937,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "uuid"
@@ -5806,7 +5831,7 @@ dependencies = [
  "serde_repr",
  "tracing",
  "uds_windows",
- "uuid",
+ "uuid 1.23.4",
  "windows-sys 0.61.2",
  "winnow 1.0.3",
  "zbus_macros",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -75,6 +75,13 @@ msedge-tts = "0.4"
 # connect). We install aws-lc-rs as the explicit process default at startup to disambiguate.
 rustls = { version = "0.23", features = ["aws_lc_rs"] }
 
+# Discord Rich Presence (PR: disc/rpc): what the user is reading, shown on their Discord profile.
+# v1.x is a from-scratch rewrite that speaks Discord's IPC protocol directly — no GameSDK, no
+# bundled DLL, and no build-time download (the old discord-sdk path fetched a binary from Discord).
+# Same client id + asset keys as any Discord application; the id lives in src/presence.rs, one
+# constant, because it must be supplied by the app owner (see the comment there). MIT.
+discord-rich-presence = "1.1"
+
 # RAWY-196: reach WebView2's own settings to strip the browser chrome (find bar, reload, print,
 # context menu). Tauri exposes none of these, so they are set through `with_webview` -> the WebView2
 # controller. Both crates are ALREADY in the tree via tauri/wry — pinned to those exact versions so

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ pub mod books; // file import, format detection, EPUB/PDF orchestration (placeho
 pub mod metadata; // read embedded metadata + persist user overrides (placeholder)
 pub mod fonts; // register/validate custom fonts (placeholder)
 pub mod photocards; // saved photo cards: PNG store + DB rows (RAWY-52, Photo Mode part 2a)
+pub mod presence; // DISC/RPC: Discord Rich Presence worker thread + the on/off gate
 pub mod settings; // key/value settings persistence
 pub mod sync; // FUTURE seam: backend trait only (placeholder)
 pub mod tts; // RAWY-105: bundled piper sidecar (persistent process) + on-demand voice download
@@ -155,6 +156,8 @@ macro_rules! sard_invoke_handler {
             tts::tts_synthesize,
             tts::tts_edge_voices,
             tts::tts_stop,
+            presence::presence_update, // DISC/RPC: push the reading activity to Discord
+            presence::presence_clear, // DISC/RPC: clear it (leaving the book, or toggled off)
             window_chrome::set_titlebar_theme,
             $($diag_cmd),*
         ])
@@ -251,6 +254,7 @@ pub fn run() {
                 db_path,
             });
             app.manage(tts::TtsEngine::default()); // RAWY-105: persistent piper process holder
+            app.manage(presence::PresenceManager::start()); // DISC/RPC: the worker thread (idle until used)
             Ok(())
         });
 
@@ -276,6 +280,12 @@ pub fn run() {
             if let tauri::RunEvent::ExitRequested { .. } = event {
                 if let Some(engine) = app_handle.try_state::<tts::TtsEngine>() {
                     tts::shutdown(&engine);
+                }
+                // DISC/RPC: clear the activity before the pipe dies, so no exit leaves a stale
+                // "reading" card on the user's Discord profile. Fire-and-forget: the worker also
+                // ends when the channel drops, and the process exit is not delayed for it.
+                if let Some(presence) = app_handle.try_state::<presence::PresenceManager>() {
+                    presence::shutdown(&presence);
                 }
             }
         });

--- a/src-tauri/src/presence.rs
+++ b/src-tauri/src/presence.rs
@@ -1,0 +1,213 @@
+//! Discord Rich Presence (feature: disc/rpc) — the reading session on your Discord profile.
+//!
+//! THE DIVISION OF LABOUR. The frontend knows what is being read; this module knows how to say it
+//! to Discord. The Reader feeds us the book title, the chapter label and the whole-book fraction;
+//! we turn that into an `Activity` (details = the book, state = chapter or "NN%", assets = Sard's
+//! mark, timestamps = when this book was opened) and push it down Discord's IPC pipe.
+//!
+//! WHY A THREAD. Every call into the GameSDK-free IPC client blocks on the pipe: `connect()` probes
+//! pipes until Discord answers, and `set_activity` writes synchronously. None of that may run on
+//! the main thread — a blocked command handler is a frozen window. So the client lives on its own
+//! thread, woken by a channel; commands enqueue and return immediately, the worker serialises the
+//! actual pipe traffic. A failed `connect()` (Discord not running) is a drop and a retry on the
+//! NEXT update — never a busy loop, never a stale client.
+//!
+//! THE OFF SWITCH IS ENFORCED HERE, NOT ONLY IN THE UI. `presence_update` reads the
+//! `discord_rpc_enabled` setting itself and no-ops when it is off. The settings toggle is the
+//! frontend's copy; this is the core's copy, so even a stale frontend (a session already in flight
+//! when the toggle was flipped, a crashed renderer) cannot leak reading state to Discord. Nothing
+//! about the feature is observable by Discord unless that key says `1`.
+//!
+//! THE CLIENT ID. The ID below is a PLACEHOLDER — the app owner must register Sard at
+//! https://discord.com/developers/applications, drop its Application ID in here, and upload the
+//! hoopoe mark as the `sard` Rich-Presence asset. With a placeholder id the IPC handshake succeeds
+//! (Discord accepts any well-formed id) but Discord's servers reject the activity, which shows up
+//! nowhere — a silent no-op, exactly like a missing Discord. The one constant is the whole
+//! integration point; nothing else knows this value exists.
+
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread::JoinHandle;
+
+use discord_rich_presence::activity::{Activity, Assets, Timestamps};
+use discord_rich_presence::{DiscordIpc, DiscordIpcClient};
+use serde::Deserialize;
+use tauri::State;
+
+use crate::db::AppState;
+use crate::settings;
+
+/// THE Discord application id — see the module note. Owner-supplied.
+const DISCORD_APPLICATION_ID: &str = "0000000000000000000";
+/// The Rich-Presence asset key for Sard's mark, registered under the Discord application above.
+const LARGE_IMAGE_KEY: &str = "sard";
+/// The app name as Discord shows it in the activity's hover text.
+const LARGE_IMAGE_TEXT: &str = "Sard · سَرْد";
+
+/// The settings key that carries the on/off switch. Absent = on (the default), exactly like
+/// `bg_enabled` — and read by BOTH sides: the toggle UI writes it, the core gate below reads it.
+pub const RPC_SETTING_KEY: &str = "discord_rpc_enabled";
+
+/// One book-open → the activity Discord shows. Shapes mirror `ipc.ts` on the frontend.
+#[derive(Deserialize, Debug)]
+pub struct PresenceActivity {
+    /// The book's title (the details line).
+    pub details: String,
+    /// Chapter label, or `"NN%"` — whatever the frontend resolved for the current position.
+    #[serde(default)]
+    pub state: Option<String>,
+    /// Epoch MILLISECONDS of the book open; the worker converts to the unix seconds Discord wants.
+    /// `None` keeps the previous session's start (it arrives on every relocate; only the first
+    /// carries a value).
+    #[serde(default)]
+    pub started_at: Option<u64>,
+}
+
+/// Messages to the worker thread. The thread OWNS the client; the manager only forwards.
+enum Msg {
+    Update(PresenceActivity),
+    Clear,
+}
+
+/// Tauri-managed handle. Cheap to clone? No — it is managed ONCE and borrowed by `State`; the
+/// thread is spawned in `start()` and told to exit through the channel in `shutdown()`.
+pub struct PresenceManager {
+    tx: Sender<Msg>,
+    #[allow(dead_code)] // joined only for diagnostics; the process exit tears the thread down anyway
+    thread: JoinHandle<()>,
+}
+
+impl PresenceManager {
+    /// Spawn the worker thread. Nothing connects until the first update arrives.
+    pub fn start() -> Self {
+        let (tx, rx) = mpsc::channel::<Msg>();
+        let thread = std::thread::Builder::new()
+            .name("sard-discord-rpc".into())
+            .spawn(move || worker(rx))
+            .expect("spawn the discord rpc worker thread");
+        PresenceManager { tx, thread }
+    }
+
+    /// Best-effort forward; the send fails only if the worker already died.
+    fn send(&self, msg: Msg) -> Result<(), String> {
+        self.tx.send(msg).map_err(|e| e.to_string())
+    }
+}
+
+/// The worker: owns the (optional) IPC client, keeps the session start time, and serialises all
+/// pipe traffic. Blocks on `recv()` when idle — costs nothing while the user just reads.
+fn worker(rx: Receiver<Msg>) {
+    let mut client: Option<DiscordIpcClient> = None;
+    let mut started_at: Option<u64> = None;
+    while let Ok(msg) = rx.recv() {
+        match msg {
+            Msg::Update(activity) => {
+                if let Some(st) = activity.started_at {
+                    started_at = Some(st);
+                }
+                // Connect lazily and RE-RETRY on every update after a failure: a reader who opens
+                // Discord after Sard must not have to reopen the book to see the presence appear.
+                if client.is_none() {
+                    let mut fresh = DiscordIpcClient::new(DISCORD_APPLICATION_ID);
+                    match fresh.connect() {
+                        Ok(()) => client = Some(fresh),
+                        Err(e) => {
+                            println!("[Sard] discord rpc: connect failed ({e}); retrying on the next update");
+                            continue;
+                        }
+                    }
+                }
+                let c = client.as_mut().expect("client was just connected");
+                let mut act = Activity::new()
+                    .details(&activity.details)
+                    .assets(Assets::new().large_image(LARGE_IMAGE_KEY).large_text(LARGE_IMAGE_TEXT));
+                if let Some(state) = activity.state.as_deref().filter(|s| !s.is_empty()) {
+                    act = act.state(state);
+                }
+                if let Some(start) = started_at {
+                    act = act.timestamps(Timestamps::new().start((start / 1000) as i64));
+                }
+                if let Err(e) = c.set_activity(act) {
+                    // A rejected activity (placeholder client id, or a stale pipe after Discord
+                    // restarted) is NOT fatal: the next update re-sends. Log and move on.
+                    println!("[Sard] discord rpc: set_activity failed ({e}); will retry");
+                    let _ = c.close();
+                    client = None;
+                }
+            }
+            Msg::Clear => {
+                started_at = None;
+                if let Some(mut c) = client.take() {
+                    let _ = c.clear_activity();
+                    let _ = c.close();
+                }
+            }
+        }
+    }
+}
+
+/// Tell the worker to clear + disconnect, then end the loop. Called from the app's exit path so no
+/// Sard exit can leave a stale "reading" activity on someone's profile.
+pub fn shutdown(manager: &PresenceManager) {
+    let _ = manager.send(Msg::Clear);
+    // No join and no explicit kill: the exit is already in flight, and the Clear sits ahead of the
+    // process teardown in the same pipe of causality. If the OS wins the race the pipe closes
+    // server-side and Discord drops the activity itself — either way nothing lingers.
+}
+
+/// Push a new activity to Discord. Gated on the persisted on/off setting — see the module note.
+#[tauri::command]
+pub fn presence_update(
+    activity: PresenceActivity,
+    state: State<AppState>,
+    presence: State<PresenceManager>,
+) -> Result<(), String> {
+    let conn = state.conn();
+    let enabled = settings::get(&conn, RPC_SETTING_KEY)
+        .map_err(|e| e.to_string())?
+        .as_deref()
+        != Some("0");
+    if !enabled {
+        return Ok(());
+    }
+    presence.send(Msg::Update(activity))
+}
+
+/// Clear the activity (leaving the book, or the setting was switched off).
+#[tauri::command]
+pub fn presence_clear(presence: State<PresenceManager>) -> Result<(), String> {
+    presence.send(Msg::Clear)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The worker must never panic, whatever the machine state: no Discord running (the common
+    /// case in tests and on most machines), a mid-session Clear, or an activity with no state
+    /// line. Each message is drained to completion so the assertions exercise the real loop.
+    #[test]
+    fn worker_survives_without_discord() {
+        let (tx, rx) = mpsc::channel::<Msg>();
+        std::thread::spawn(move || worker(rx));
+
+        tx.send(Msg::Clear).unwrap(); // nothing connected yet — must be a no-op
+        tx.send(Msg::Update(PresenceActivity {
+            details: "A book".into(),
+            state: None,
+            started_at: None,
+        }))
+        .unwrap();
+        tx.send(Msg::Update(PresenceActivity {
+            details: "A book".into(),
+            state: Some("Chapter 1".into()),
+            started_at: Some(1_700_000_000_000),
+        }))
+        .unwrap();
+        tx.send(Msg::Clear).unwrap();
+
+        // Give the worker time to drain the four messages. It only exits on channel close, so
+        // dropping the sender is the shutdown signal — same as the app's exit path.
+        drop(tx);
+        std::thread::sleep(std::time::Duration::from_millis(300));
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { initStyleScope } from "./lib/styleScope";
 import { diagStart } from "@diag"; // DIAGNOSTIC BUILD ONLY - observes, never intervenes
 import { registerOutcomeRecorder } from "./lib/listeningOutcomes"; // RAWY-263: the local outcome baseline
 import { initTheme, reapplyTitlebarTheme, useTheme, THEMES } from "./theme";
+import { initPresence } from "./lib/presence"; // DISC/RPC: load the Discord on/off switch
 import { LanguagePicker } from "./features/onboarding/LanguagePicker";
 import { Library, type OpenTarget } from "./features/library/Library";
 import { Reader } from "./features/reader/Reader";
@@ -70,6 +71,7 @@ function App() {
     // Applying it later would paint the themed ground first and then swap — the RAWY-118 class of flash.
     initBackground();
     registerOutcomeRecorder(); // RAWY-263: observe listening outcomes locally. Read-only; never writes while audio plays.
+    initPresence(); // DISC/RPC: load the persisted Discord on/off switch
   }, []);
 
   // RAWY-265 — the library background is re-derived whenever the LIBRARY theme or any of its own

--- a/src/features/reader/Reader.tsx
+++ b/src/features/reader/Reader.tsx
@@ -65,6 +65,7 @@ import { useBookmarks } from "./bookmarksStore";
 import { ReaderChrome, type SettingsSection } from "./ReaderChrome";
 import { SettingsPanel } from "./SettingsPanel";
 import { useReadMarkerStyle } from "../../lib/readMarkerStyle"; // RAWY-256: the global read-marker variant
+import { endReadingSession, startReadingSession, updateReadingSession } from "../../lib/presence"; // DISC/RPC
 import { ReturnPill } from "./ReturnPill"; // RAWY-250: the return-to-reading-position pill
 import { TtsPlayer } from "./TtsPlayer";
 import { releaseButtonFocusAfterPointerClick, skipSentenceForArrow, useTts } from "../../lib/tts";
@@ -507,6 +508,9 @@ export function Reader({
       ctrl.onRelocate(({ cfi, fraction, chapterLabel, chapterHref, location, pageLabel }) => {
         // WP-4F: `location`/`pageLabel` are foliate's own position data, which used to be dropped here.
         set({ cfi, fraction, chapterLabel, chapterHref, location, pageLabel });
+        // DISC/RPC: the activity's position line follows the real reading position — the chapter
+        // label when the engine has one, else the whole-book percent. Throttled inside.
+        updateReadingSession(chapterLabel, fraction);
         // RAWY-190: if read-aloud finished a chapter (status "chapter-end") and the user navigated to a
         // DIFFERENT section, the stale "next chapter" offer no longer applies (its button would advance
         // from the chapter on screen, which is now the one the user moved to — not the finished one). Stop
@@ -617,6 +621,10 @@ export function Reader({
         bookAuthor: meta?.author ?? null,
         bookScript: meta?.script ?? null, // WP-5A: what the read-aloud pre-flight gates on
       });
+      // DISC/RPC: a NEW session starts the moment the book is readable. The details line is the
+      // database name (the same `meta` every other surface resolves) and the clock starts now; the
+      // first relocate below fills the position line in.
+      startReadingSession((meta?.title ?? target.title ?? "").trim() || t("app.name"));
       if (targetIsPdf) setPdfPageCount(ctrl.pdfPageCount); // RAWY-87: total pages for the position readout
       setToc(ctrl.getToc()); // chapters panel (RAWY-21)
       setTocSecMap(ctrl.tocHrefSectionMap()); // RAWY-256: one pass, reused by every marker render
@@ -782,6 +790,10 @@ export function Reader({
       useTts.getState().stop();
       // The photo-card basket is a per-reading-session collection (RAWY-60) — clear it on exit.
       usePhotoBasket.getState().clear();
+      // DISC/RPC: this reading session is over — clear the activity off Discord. Runs on every
+      // exit path (Back to Library, a cross-book follow, the error screen) because all of them
+      // either unmount the Reader or change `initial.id`, and this cleanup covers both.
+      endReadingSession();
       // Restore the LIBRARY theme to the chrome on exit (RAWY-40/48) — the book theme was only
       // for this reading session; the Library shows its own independent theme again.
       applyTheme(THEMES[libraryThemeRef.current]);

--- a/src/features/settings/GlobalSettings.tsx
+++ b/src/features/settings/GlobalSettings.tsx
@@ -21,6 +21,7 @@ import { BG_BLUR_MAX, BG_PRESENCE_MAX, bgSrcUrl, useBackground } from "../../lib
 import { BOOKMARK_COLORS, BOOKMARK_SHAPES, BOOKMARK_SIZE_MAX, BOOKMARK_SIZE_MIN, useBookmarkStyle } from "../../lib/bookmarkStyle";
 import { BookmarkShape } from "../reader/BookmarkShape";
 import { READ_MARKERS, useReadMarkerStyle } from "../../lib/readMarkerStyle"; // RAWY-256
+import { usePresence } from "../../lib/presence"; // DISC/RPC: the Discord on/off switch
 import { TtsTrackingControls } from "../reader/TtsTrackingControls"; // RAWY-200
 import { useStyleScope } from "../../lib/styleScope";
 import {
@@ -35,13 +36,14 @@ import { THEMES, THEME_ORDER, currentMode, useTheme, type ThemeMode } from "../.
 
 const STYLE_KEY = "reading_style";
 
-type Section = "appearance" | "fonts" | "reading" | "bookmark" | "language" | "about";
+type Section = "appearance" | "fonts" | "reading" | "bookmark" | "language" | "presence" | "about";
 const NAV: { key: Section; label: TKey; icon: string }[] = [
   { key: "appearance", label: "gs.nav.appearance", icon: "◑" },
   { key: "fonts", label: "gs.nav.fonts", icon: "A" },
   { key: "reading", label: "gs.nav.reading", icon: "▤" },
   { key: "bookmark", label: "gs.nav.bookmark", icon: "▸" },
   { key: "language", label: "gs.nav.language", icon: "⌘" },
+  { key: "presence", label: "gs.nav.presence", icon: "◉" },
   { key: "about", label: "gs.nav.about", icon: "ⓘ" },
 ];
 
@@ -91,6 +93,7 @@ export function GlobalSettings({ open, onClose }: { open: boolean; onClose: () =
             {section === "reading" && <ReadingDefaultsSection />}
             {section === "bookmark" && <BookmarkSection />}
             {section === "language" && <LanguageSection />}
+            {section === "presence" && <PresenceSection />}
             {section === "about" && <AboutSection />}
           </div>
         </div>
@@ -852,6 +855,30 @@ function LanguageSection() {
         <div className="gs-note">{t("gs.languageHint")}</div>
       </div>
       <TwoLevelCard />
+    </>
+  );
+}
+
+// DISC/RPC: the one switch. One row while off, one row while on — the smallest possible surface
+// for a feature whose whole point is "show me, unless I say stop". Reuses the house toggle idiom
+// (`rs-toggle-row` / `BgToggle`) so the knob, the RTL pin and the a11y wiring are the ones the
+// rest of the app already uses.
+function PresenceSection() {
+  const { t } = useI18n();
+  const enabled = usePresence((s) => s.enabled);
+  const setEnabled = usePresence((s) => s.setEnabled);
+  return (
+    <>
+      <SecHead>{t("gs.presence")}</SecHead>
+      <div className="gs-sec">
+        <BgToggle
+          label={t("gs.presence.enabled")}
+          hint={t("gs.presence.enabledHint")}
+          on={enabled}
+          onToggle={() => setEnabled(!enabled)}
+        />
+      </div>
+      <div className="gs-note">{t("gs.presence.note")}</div>
     </>
   );
 }

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -519,6 +519,7 @@ export const ar: Record<TKey, string> = {
   "gs.nav.reading": "أنماط الكتب", // RAWY-284 — انظر "gs.reading"
   "gs.nav.bookmark": "شكل الفاصل",
   "gs.nav.language": "اللغة",
+  "gs.nav.presence": "الحضور",
   "gs.nav.about": "حول",
   "gs.appearance": "المظهر",
   "gs.mode": "الوضع",
@@ -556,6 +557,11 @@ export const ar: Record<TKey, string> = {
   "gs.language": "اللغة",
   "gs.languageHint": "تضبط لغة الواجهة واتجاهها. اتجاه الكتاب نفسه لا يتأثر.",
   "gs.about": "حول",
+  // DISC/RPC: قسم الحضور في ديسكورد — مفتاح واحد فقط؛ الميزة «مفعّلة ما لم يُطلب إيقافها».
+  "gs.presence": "الحضور في ديسكورد",
+  "gs.presence.enabled": "إظهار نشاط القراءة على ديسكورد",
+  "gs.presence.enabledHint": "أثناء قراءتك يظهر على ملفك في ديسكورد اسم الكتاب وموضعك فيه.",
+  "gs.presence.note": "يظهر فقط عند فتح كتاب، وفقط عند تشغيل تطبيق ديسكورد على الجهاز. لا يُشارَك سوى اسم الكتاب وموضعك — لا ملاحظات ولا تظليل ولا بحث ولا ملفات.",
   "gs.about.version": "الإصدار",
   "gs.about.beta": "نسخة تجريبية",
   "gs.about.buildId": "معرّف البناء",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -525,6 +525,7 @@ export const en = {
   "gs.nav.reading": "Book styles", // RAWY-284 — see "gs.reading"
   "gs.nav.bookmark": "Bookmark style",
   "gs.nav.language": "Language",
+  "gs.nav.presence": "Presence", // DISC/RPC
   "gs.nav.about": "About",
   "gs.appearance": "Appearance",
   "gs.mode": "MODE",
@@ -563,6 +564,11 @@ export const en = {
   "gs.language": "Language",
   "gs.languageHint": "Sets the interface language and direction. The book's own direction is unaffected.",
   "gs.about": "About",
+  // DISC/RPC: the Discord presence section. Exactly one switch — the feature is "on, unless told".
+  "gs.presence": "Discord Rich Presence",
+  "gs.presence.enabled": "Show reading activity on Discord",
+  "gs.presence.enabledHint": "While you read, your Discord profile shows the book and your progress in it.",
+  "gs.presence.note": "Shows only while a book is open, and only when the Discord desktop app is running. Only the book title and your position are ever shared — no notes, highlights, searches or files.",
   "gs.about.version": "Version",
   "gs.about.beta": "Beta Build",
   "gs.about.buildId": "BUILD ID",

--- a/src/lib/presence.ts
+++ b/src/lib/presence.ts
@@ -1,0 +1,111 @@
+// Discord Rich Presence (feature: disc/rpc) — what the Reader shows on your Discord profile.
+//
+// Owns the on/off setting and the ONE reading session the app may have (the Reader is reused
+// across books, so a session belongs to a book-open, not to a mount). The Rust side enforces the
+// same setting again in `presence_update`; this store is the UI's copy of the switch.
+//
+// WHAT GETS SENT is deliberately small and deliberately shaped by the reader: details = the book
+// title, state = the chapter label (or "NN%"), plus the book-open timestamp. No highlights, no
+// notes, no search terms, no file paths ever leave the machine. Discord shows it only while a
+// book is open and only when the Discord desktop app is running.
+
+import { invoke } from "@tauri-apps/api/core";
+import { create } from "zustand";
+
+import { settingsGet, settingsSet } from "./ipc";
+
+const K_ENABLED = "discord_rpc_enabled";
+
+export interface PresenceState {
+  ready: boolean;
+  enabled: boolean;
+  setEnabled: (v: boolean) => void;
+}
+
+export const usePresence = create<PresenceState>((set) => ({
+  ready: false,
+  enabled: true,
+  setEnabled: (v) => {
+    set({ enabled: v });
+    settingsSet(K_ENABLED, v ? "1" : "0").catch(console.error);
+    if (v) {
+      // Turning it back ON mid-book: re-send the live session instead of waiting for the next
+      // page turn (which, in a long chapter, may be minutes away).
+      refreshSession();
+    } else {
+      presenceClear().catch(() => {});
+    }
+  },
+}));
+
+/** Load the persisted switch at startup, alongside every other `init*` (App.tsx). */
+export async function initPresence() {
+  const raw = await settingsGet(K_ENABLED).catch(() => null);
+  usePresence.setState({ enabled: raw !== "0", ready: true });
+}
+
+// ---- the reading session --------------------------------------------------
+
+interface Session {
+  details: string;
+  state: string | null;
+  startedAt: number;
+}
+
+let session: Session | null = null;
+let lastSentAt = 0;
+let lastChapter: string | null = null;
+let lastPct = -1;
+
+// Discord rate-limits SET_ACTIVITY (~5 per 20 s); a chapter change or a 1 % step is plenty of
+// resolution for a reading status, and both are re-checked before every send (see push()).
+const THROTTLE_MS = 10_000;
+
+/** The book opened: start the session, with the clock running from right now. */
+export function startReadingSession(details: string) {
+  session = { details, state: null, startedAt: Date.now() };
+  lastChapter = null;
+  lastPct = -1;
+  push();
+}
+
+/** A relocate arrived: refresh the position line (chapter label, else whole-book percent). */
+export function updateReadingSession(chapterLabel: string | null, fraction: number) {
+  if (!session) return;
+  const pct = Math.min(100, Math.max(0, Math.round(fraction * 100)));
+  const chapter = chapterLabel?.trim() || null;
+  if (chapter === lastChapter && pct === lastPct) return; // nothing a viewer would notice changed
+  lastChapter = chapter;
+  lastPct = pct;
+  session.state = chapter ?? `${pct}%`;
+  push();
+}
+
+/** The book closed (Back to Library, another book, window close): the activity must disappear. */
+export function endReadingSession() {
+  session = null;
+  presenceClear().catch(() => {});
+}
+
+function push() {
+  const s = session;
+  if (!s) return;
+  if (!usePresence.getState().enabled) return;
+  const now = Date.now();
+  if (now - lastSentAt < THROTTLE_MS) return;
+  lastSentAt = now;
+  presenceUpdate(s).catch(() => {});
+}
+
+function refreshSession() {
+  if (!session) return;
+  lastSentAt = 0; // bypass the throttle: this is a deliberate re-send, not a stream
+  push();
+}
+
+const presenceUpdate = (s: Session): Promise<void> =>
+  invoke<void>("presence_update", {
+    activity: { details: s.details, state: s.state, startedAt: s.startedAt },
+  });
+
+const presenceClear = (): Promise<void> => invoke<void>("presence_clear");


### PR DESCRIPTION
## What

Shows what the user is reading on their Discord profile, while a book is open:

- **Book + position**: the details line is the book's name (the same `meta` every other surface resolves); the state line follows the real reading position — the chapter label, or the whole-book percentage when the engine has none — throttled to one update per 10s and deduped on chapter/percent.
- **A session clock** on the activity timestamps (epoch-millis `started_at` from the reader store, converted to unix seconds).
- **On/off switch in Global Settings** ("Presence" section, between Language and About), persisted as `discord_rpc_enabled` and enforced in BOTH the frontend store and the Rust `presence_update` command (absent = enabled, same convention as `bg_enabled`).
- **Clean exit**: clears the activity on reader unmount and on app shutdown, so no stale "reading" card survives.

## Implementation

- `discord-rich-presence = "1.1"` — a from-scratch rewrite that speaks Discord's IPC protocol directly: no GameSDK, no bundled DLL, no build-time download. MIT.
- A `PresenceManager` (managed Tauri state) owns a background worker thread fed by an mpsc channel; lazy connect on first use, retries on the next update if Discord isn't running. This keeps the IPC out of the async command runtime.
- Frontend: a tiny Zustand store (`src/lib/presence.ts`) — `initPresence()`, session helpers, and `presenceUpdate`/`presenceClear` IPC wrappers; wired in `App.tsx`, `Reader.tsx` (open/relocate/unmount) and `GlobalSettings.tsx`.
- i18n: new `gs.*presence*` keys in `en.ts` + `ar.ts`.
- New unit test `presence::tests::worker_survives_without_discord` (worker must never panic when Discord isn't running).

## Required: your Discord application ID

The crate needs a real application ID before Discord will accept any activity. It is intentionally one constant — `DISCORD_APPLICATION_ID` in `src-tauri/src/presence.rs` — currently the placeholder `0000000000000000000`:

1. Create an application at https://discord.com/developers/applications
2. Add a large asset named `sard` under **Rich Presence → Art Assets** (with text `Sard · سَرْد`)
3. Replace the placeholder in `src-tauri/src/presence.rs`

Until then the app degrades gracefully: the worker logs the rejection and nothing else changes.

## Verification

- `cargo check`, `cargo clippy` (lib) clean; debug + full binary builds pass
- `npm run build` (tsc + vite) passes
- `cargo test --lib`: 28/28 pass including the new worker test (the repo's local-only test module files `wp2_tests`/etc. are stubbed locally — they are not in the checkout; CI doesn't run cargo test)
